### PR TITLE
Fix for the latest libsyntax

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -83,7 +83,7 @@ impl<'a> visit::Visitor<'a> for Builder<'a> {
             let name = item.ident.to_string();
             {
                 let tree = self.tree.subtree_at_path(&self.path).unwrap();
-                let visibility = if item.vis == ast::Visibility::Public {
+                let visibility = if item.vis.node == ast::VisibilityKind::Public {
                     Visibility::Public
                 } else {
                     Visibility::Private


### PR DESCRIPTION
rust-lang/rust#47799 broke cargo-modules, which this PR fixes.