### PR TITLE
Detect edition

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,12 @@
+use json;
+use std::io;
+
+#[derive(Debug)]
+pub enum Error {
+    CargoExecutionFailed(io::Error),
+    InvalidManifestJson(json::JsonError),
+    NoLibraryTargetFound,
+    NoMatchingBinaryTargetFound,
+    NoTargetProvided,
+    Syntax(String),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn choose_target<'a>(args: &Arguments, manifest: &'a Manifest) -> Result<&'a Tar
         manifest
             .targets
             .iter()
-            .find(|t| t.is_bin() && &t.name == name)
+            .find(|t| t.is_bin() && &t.name() == &name)
             .ok_or(Error::NoMatchingBinaryTargetFound)
     } else if manifest.targets.len() == 1 {
         // If neither `--lib` is enabled nor `--bin` target is specified but
@@ -77,19 +77,12 @@ fn run(args: &Arguments) -> Result<(), Error> {
     let build_scripts: Vec<path::PathBuf> = manifest
         .custom_builds()
         .iter()
-        .map(|t| path::Path::new(t.src_path()).to_path_buf())
+        .map(|t| t.src_path().clone())
         .collect();
 
-    let (target_name, src_path): (&str, &str) = {
+    let (target_name, src_path): (&str, &path::Path) = {
         let target: &Target = try!(choose_target(args, &manifest));
-        (
-            &target.name,
-            target
-                .src_path
-                .to_str()
-                // TODO: move this on Target
-                .expect("Expected `src_path` property."),
-        )
+        (target.name(), target.src_path().as_path())
     };
     let parse_session = ParseSess::new(source_map::FilePathMapping::empty());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ extern crate syntax;
 
 mod builder;
 mod dot_printer;
+mod error;
+mod manifest;
 mod printer;
 mod tree;
 
@@ -23,20 +25,15 @@ use colored::*;
 use builder::Builder;
 use builder::Config as BuilderConfig;
 
+use error::Error;
+
+use manifest::Manifest;
+
 use printer::Config as PrinterConfig;
 use printer::Printer;
 
 use dot_printer::Config as DotPrinterConfig;
 use dot_printer::DotPrinter;
-
-pub enum Error {
-    CargoExecutionFailed(io::Error),
-    InvalidManifestJson(json::JsonError),
-    NoLibraryTargetFound,
-    NoMatchingBinaryTargetFound,
-    NoTargetProvided,
-    Syntax(String),
-}
 
 fn get_manifest() -> Result<json::JsonValue, Error> {
     let output = process::Command::new("cargo").arg("read-manifest").output();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ fn choose_target<'a>(args: &Arguments, manifest: &'a Manifest) -> Result<&'a Tar
         manifest
             .targets
             .iter()
-            .find(|t| t.is_bin() && &t.name() == &name)
+            .find(|t| t.is_bin() && t.name() == name)
             .ok_or(Error::NoMatchingBinaryTargetFound)
     } else if manifest.targets.len() == 1 {
         // If neither `--lib` is enabled nor `--bin` target is specified but

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use builder::Config as BuilderConfig;
 
 use error::Error;
 
-use manifest::{Manifest, Target};
+use manifest::{Edition, Manifest, Target};
 
 use printer::Config as PrinterConfig;
 use printer::Printer;
@@ -71,6 +71,14 @@ fn run(args: &Arguments) -> Result<(), Error> {
         let json_string = String::from_utf8(stdout).expect("Failed reading cargo output");
         Manifest::from_str(&json_string)?
     };
+
+    if args.enable_edition_2018 && manifest.edition == Edition::E2018 {
+        println!(
+            "{}\n{}",
+            "Edition 2018 support is work in progress.".red(),
+            "`--enable-edition-2018` will be ignored.".red()
+        );
+    }
 
     // TODO: Check to see if build scripts really need to be ignored.
     //       Seems like they are not mistaken as orphans anyway.
@@ -174,7 +182,7 @@ struct Arguments {
 
     /// [Experimental] Enable support for edition 2018 of Rust (ignored)
     #[structopt(long = "enable-edition-2018")]
-    _enable_edition_2018: bool,
+    enable_edition_2018: bool,
 
     /// Sets an explicit crate path (ignored)
     #[structopt(name = "CRATE_DIR")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,8 @@ fn run(args: &Arguments) -> Result<(), Error> {
 
     let json = try!(get_manifest());
     let target_cfgs: Vec<_> = json["targets"].members().cloned().collect();
+    // TODO: Check to see if build scripts really need to be ignored.
+    //       Seems like they are not mistaken as orphans anyway.
     let build_scripts: Vec<path::PathBuf> = manifest
         .custom_builds()
         .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ mod manifest;
 mod printer;
 mod tree;
 
+use std::path;
 use std::process;
-use std::{io, path};
 
 use syntax::ast::NodeId;
 use syntax::parse::{self, ParseSess};

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -77,39 +77,33 @@ mod tests {
     use super::*;
     use std::fs;
 
+    fn read_manifest(filename: &str) -> Manifest {
+        let manifest_str: String =
+            fs::read_to_string(filename).expect("manifest file cannot be read");
+        Manifest::from_str(&manifest_str).expect("manifest cannot be read")
+    }
+
     #[test]
     fn manifest_with_edition2018_can_be_parsed() {
-        let manifest_filename = "test-resources/example-edition-2018.json";
-        let manifest_str: String =
-            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
-        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        let manifest = read_manifest("test-resources/example-edition-2018.json");
         assert_eq!(Edition::E2018, manifest.edition);
     }
 
     #[test]
     fn manifest_with_edition2015_can_be_parsed() {
-        let manifest_filename = "test-resources/example-edition-2015.json";
-        let manifest_str: String =
-            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
-        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        let manifest = read_manifest("test-resources/example-edition-2015.json");
         assert_eq!(Edition::E2015, manifest.edition);
     }
 
     #[test]
     fn manifest_without_edition_can_be_parsed() {
-        let manifest_filename = "test-resources/example-no-edition.json";
-        let manifest_str: String =
-            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
-        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        let manifest = read_manifest("test-resources/example-no-edition.json");
         assert_eq!(Edition::E2015, manifest.edition);
     }
 
     #[test]
     fn manifest_for_simple_lib() {
-        let manifest_filename = "test-resources/example-lib.json";
-        let manifest_str: String =
-            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
-        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        let manifest = read_manifest("test-resources/example-lib.json");
         assert_eq!(
             Target::Lib {
                 kind: vec!(String::from("lib")),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -67,7 +67,6 @@ impl Target {
         let name: String = j["name"].take_string().expect("name is missing");
         let src_path: String = j["src_path"].take_string().expect("src_path is missing");
         let edition: Option<String> = j["edition"].take_string();
-        // lib | rlib | staticlib | dylib
         Target {
             kind,
             crate_types,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,70 @@
+use error::Error;
+use json;
+use std::default::Default;
+
+#[derive(Debug, Default)]
+pub struct Manifest {
+    pub edition: Edition,
+}
+
+impl Manifest {
+    fn from_str(src: &str) -> Result<Self, Error> {
+        let j = json::parse(src).map_err(Error::InvalidManifestJson)?;
+
+        println!("{:?}", j);
+
+        let edition: Edition = match j["edition"].as_str() {
+            Some("2015") => Edition::E2015,
+            Some("2018") => Edition::E2018,
+            Some(unknown) => panic!("Unrecognized value for edition \"{}\"", unknown),
+            None => Edition::default(),
+        };
+
+        Result::Ok(Manifest { edition })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Edition {
+    E2015,
+    E2018,
+}
+
+impl Default for Edition {
+    fn default() -> Self {
+        Edition::E2015
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn manifest_with_edition2018_can_be_parsed() {
+        let manifest_filename = "test-resources/example-edition-2018.json";
+        let manifest_str: String =
+            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
+        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        assert_eq!(Edition::E2018, manifest.edition);
+    }
+
+    #[test]
+    fn manifest_with_edition2015_can_be_parsed() {
+        let manifest_filename = "test-resources/example-edition-2015.json";
+        let manifest_str: String =
+            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
+        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        assert_eq!(Edition::E2015, manifest.edition);
+    }
+
+    #[test]
+    fn manifest_without_edition_can_be_parsed() {
+        let manifest_filename = "test-resources/example-no-edition.json";
+        let manifest_str: String =
+            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
+        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        assert_eq!(Edition::E2015, manifest.edition);
+    }
+}

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -98,10 +98,7 @@ impl Target {
     }
 
     fn is_lib(&self) -> bool {
-        self.kind
-            .iter()
-            .find(|k| Self::LIB_KINDS.contains(&&k[..]))
-            .is_some()
+        self.kind.iter().any(|k| Self::LIB_KINDS.contains(&&k[..]))
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,13 +5,12 @@ use std::default::Default;
 #[derive(Debug, Default)]
 pub struct Manifest {
     pub edition: Edition,
+    pub targets: Vec<Target>,
 }
 
 impl Manifest {
     fn from_str(src: &str) -> Result<Self, Error> {
-        let j = json::parse(src).map_err(Error::InvalidManifestJson)?;
-
-        println!("{:?}", j);
+        let mut j = json::parse(src).map_err(Error::InvalidManifestJson)?;
 
         let edition: Edition = match j["edition"].as_str() {
             Some("2015") => Edition::E2015,
@@ -20,7 +19,9 @@ impl Manifest {
             None => Edition::default(),
         };
 
-        Result::Ok(Manifest { edition })
+        let targets: Vec<Target> = j["targets"].members_mut().map(Target::from_json).collect();
+
+        Result::Ok(Manifest { edition, targets })
     }
 }
 
@@ -33,6 +34,41 @@ pub enum Edition {
 impl Default for Edition {
     fn default() -> Self {
         Edition::E2015
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Target {
+    Lib {
+        kind: Vec<String>,
+        crate_types: Vec<String>,
+        name: String,
+        src_path: String,
+        edition: Option<String>,
+    },
+}
+
+impl Target {
+    fn from_json(j: &mut json::JsonValue) -> Target {
+        Target::Lib {
+            kind: {
+                assert!(j["kind"].is_array());
+                j["kind"]
+                    .members_mut()
+                    .map(|k| k.take_string().unwrap())
+                    .collect()
+            },
+            crate_types: {
+                assert!(j["crate_types"].is_array());
+                j["crate_types"]
+                    .members_mut()
+                    .map(|k| k.take_string().unwrap())
+                    .collect()
+            },
+            name: j["name"].take_string().expect("name is missing"),
+            src_path: j["src_path"].take_string().expect("src_path is missing"),
+            edition: j["edition"].take_string(),
+        }
     }
 }
 
@@ -66,5 +102,23 @@ mod tests {
             fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
         let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
         assert_eq!(Edition::E2015, manifest.edition);
+    }
+
+    #[test]
+    fn manifest_for_simple_lib() {
+        let manifest_filename = "test-resources/example-lib.json";
+        let manifest_str: String =
+            fs::read_to_string(manifest_filename).expect("manifest file cannot be read");
+        let manifest = Manifest::from_str(&manifest_str).expect("manifest cannot be read");
+        assert_eq!(
+            Target::Lib {
+                kind: vec!(String::from("lib")),
+                crate_types: vec!(String::from("lib")),
+                name: String::from("example-lib"),
+                src_path: String::from("/home/muhuk/Documents/code/example-lib/src/lib.rs"),
+                edition: Some(String::from("2018"))
+            },
+            manifest.targets[0]
+        );
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -47,11 +47,11 @@ impl Default for Edition {
 
 #[derive(Debug, PartialEq)]
 pub struct Target {
-    kind: Vec<String>,
-    crate_types: Vec<String>,
-    name: String,
-    src_path: PathBuf,
-    edition: Option<String>,
+    pub kind: Vec<String>,
+    pub crate_types: Vec<String>,
+    pub name: String,
+    pub src_path: PathBuf,
+    pub edition: Option<String>,
 }
 
 impl Target {
@@ -59,6 +59,14 @@ impl Target {
 
     pub fn src_path(&self) -> &PathBuf {
         &self.src_path
+    }
+
+    pub fn is_bin(&self) -> bool {
+        self.kind.contains(&String::from("bin"))
+    }
+
+    pub fn is_lib(&self) -> bool {
+        self.kind.iter().any(|k| Self::LIB_KINDS.contains(&&k[..]))
     }
 
     fn from_json(j: &mut json::JsonValue) -> Target {
@@ -89,16 +97,8 @@ impl Target {
         }
     }
 
-    fn is_bin(&self) -> bool {
-        self.kind.contains(&String::from("bin"))
-    }
-
     fn is_custom_build(&self) -> bool {
         self.kind.contains(&String::from("custom-build"))
-    }
-
-    fn is_lib(&self) -> bool {
-        self.kind.iter().any(|k| Self::LIB_KINDS.contains(&&k[..]))
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -9,7 +9,7 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    fn from_str(src: &str) -> Result<Self, Error> {
+    pub fn from_str(src: &str) -> Result<Self, Error> {
         let mut j = json::parse(src).map_err(Error::InvalidManifestJson)?;
 
         let edition: Edition = match j["edition"].as_str() {
@@ -78,6 +78,10 @@ impl Target {
 
     fn is_bin(&self) -> bool {
         self.kind.contains(&String::from("bin"))
+    }
+
+    fn is_custom_build(&self) -> bool {
+        self.kind.contains(&String::from("custom-build"))
     }
 
     fn is_lib(&self) -> bool {
@@ -149,5 +153,34 @@ mod tests {
         );
         assert!(manifest.targets[0].is_bin());
         assert!(!manifest.targets[0].is_lib());
+    }
+
+    #[test]
+    fn manifest_with_custom_build() {
+        let manifest = read_manifest("test-resources/example-custom-build.json");
+        assert_eq!(
+            vec![
+                Target {
+                    kind: vec!(String::from("lib")),
+                    crate_types: vec!(String::from("lib")),
+                    name: String::from("example-custom-build"),
+                    src_path: String::from(
+                        "/home/muhuk/Documents/code/example-custom-build/src/lib.rs"
+                    ),
+                    edition: Some(String::from("2018"))
+                },
+                Target {
+                    kind: vec!(String::from("custom-build")),
+                    crate_types: vec!(String::from("bin")),
+                    name: String::from("build-script-build"),
+                    src_path: String::from(
+                        "/home/muhuk/Documents/code/example-custom-build/build.rs"
+                    ),
+                    edition: Some(String::from("2018"))
+                }
+            ],
+            manifest.targets
+        );
+        assert!(manifest.targets[1].is_custom_build());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -47,15 +47,19 @@ impl Default for Edition {
 
 #[derive(Debug, PartialEq)]
 pub struct Target {
-    pub kind: Vec<String>,
-    pub crate_types: Vec<String>,
-    pub name: String,
-    pub src_path: PathBuf,
-    pub edition: Option<String>,
+    kind: Vec<String>,
+    crate_types: Vec<String>,
+    name: String,
+    src_path: PathBuf,
+    edition: Option<String>,
 }
 
 impl Target {
     const LIB_KINDS: [&'static str; 4] = ["lib", "rlib", "dylib", "staticlib"];
+
+    pub fn name(&self) -> &String {
+        &self.name
+    }
 
     pub fn src_path(&self) -> &PathBuf {
         &self.src_path

--- a/test-resources/example-bin.json
+++ b/test-resources/example-bin.json
@@ -1,0 +1,35 @@
+{
+  "name": "example-bin",
+  "version": "0.1.0",
+  "id": "example-bin 0.1.0 (path+file:///home/muhuk/Documents/code/example-bin)",
+  "license": null,
+  "license_file": null,
+  "description": null,
+  "source": null,
+  "dependencies": [],
+  "targets": [
+    {
+      "kind": [
+        "bin"
+      ],
+      "crate_types": [
+        "bin"
+      ],
+      "name": "example-bin",
+      "src_path": "/home/muhuk/Documents/code/example-bin/src/main.rs",
+      "edition": "2018"
+    }
+  ],
+  "features": null,
+  "manifest_path": "/home/muhuk/Documents/code/example-bin/Cargo.toml",
+  "metadata": null,
+  "authors": [
+    "Atamert Ölçgen <muhuk@muhuk.com>"
+  ],
+  "categories": [],
+  "keywords": [],
+  "readme": null,
+  "repository": null,
+  "edition": "2018",
+  "links": null
+}

--- a/test-resources/example-custom-build.json
+++ b/test-resources/example-custom-build.json
@@ -1,0 +1,46 @@
+{
+  "name": "example-custom-build",
+  "version": "0.1.0",
+  "id": "example-custom-build 0.1.0 (path+file:///home/muhuk/Documents/code/example-custom-build)",
+  "license": null,
+  "license_file": null,
+  "description": null,
+  "source": null,
+  "dependencies": [],
+  "targets": [
+    {
+      "kind": [
+        "lib"
+      ],
+      "crate_types": [
+        "lib"
+      ],
+      "name": "example-custom-build",
+      "src_path": "/home/muhuk/Documents/code/example-custom-build/src/lib.rs",
+      "edition": "2018"
+    },
+    {
+      "kind": [
+        "custom-build"
+      ],
+      "crate_types": [
+        "bin"
+      ],
+      "name": "build-script-build",
+      "src_path": "/home/muhuk/Documents/code/example-custom-build/build.rs",
+      "edition": "2018"
+    }
+  ],
+  "features": null,
+  "manifest_path": "/home/muhuk/Documents/code/example-custom-build/Cargo.toml",
+  "metadata": null,
+  "authors": [
+    "Atamert Ölçgen <muhuk@muhuk.com>"
+  ],
+  "categories": [],
+  "keywords": [],
+  "readme": null,
+  "repository": null,
+  "edition": "2018",
+  "links": null
+}

--- a/test-resources/example-edition-2015.json
+++ b/test-resources/example-edition-2015.json
@@ -1,0 +1,35 @@
+{
+  "name": "example-edition-2015",
+  "version": "0.1.0",
+  "id": "example-edition-2015 0.1.0 (path+file:///home/muhuk/Documents/code/example-edition-2015)",
+  "license": null,
+  "license_file": null,
+  "description": null,
+  "source": null,
+  "dependencies": [],
+  "targets": [
+    {
+      "kind": [
+        "lib"
+      ],
+      "crate_types": [
+        "lib"
+      ],
+      "name": "example-edition-2015",
+      "src_path": "/home/muhuk/Documents/code/example-edition-2015/src/lib.rs",
+      "edition": "2015"
+    }
+  ],
+  "features": null,
+  "manifest_path": "/home/muhuk/Documents/code/example-edition-2015/Cargo.toml",
+  "metadata": null,
+  "authors": [
+    "Atamert Ölçgen <muhuk@muhuk.com>"
+  ],
+  "categories": [],
+  "keywords": [],
+  "readme": null,
+  "repository": null,
+  "edition": "2015",
+  "links": null
+}

--- a/test-resources/example-edition-2018.json
+++ b/test-resources/example-edition-2018.json
@@ -1,0 +1,35 @@
+{
+  "name": "example-edition-2018",
+  "version": "0.1.0",
+  "id": "example-edition-2018 0.1.0 (path+file:///home/muhuk/Documents/code/example-edition-2018)",
+  "license": null,
+  "license_file": null,
+  "description": null,
+  "source": null,
+  "dependencies": [],
+  "targets": [
+    {
+      "kind": [
+        "lib"
+      ],
+      "crate_types": [
+        "lib"
+      ],
+      "name": "example-edition-2018",
+      "src_path": "/home/muhuk/Documents/code/example-edition-2018/src/lib.rs",
+      "edition": "2018"
+    }
+  ],
+  "features": null,
+  "manifest_path": "/home/muhuk/Documents/code/example-edition-2018/Cargo.toml",
+  "metadata": null,
+  "authors": [
+    "Atamert Ölçgen <muhuk@muhuk.com>"
+  ],
+  "categories": [],
+  "keywords": [],
+  "readme": null,
+  "repository": null,
+  "edition": "2018",
+  "links": null
+}

--- a/test-resources/example-lib.json
+++ b/test-resources/example-lib.json
@@ -1,0 +1,35 @@
+{
+  "name": "example-lib",
+  "version": "0.1.0",
+  "id": "example-lib 0.1.0 (path+file:///home/muhuk/Documents/code/example-lib)",
+  "license": null,
+  "license_file": null,
+  "description": null,
+  "source": null,
+  "dependencies": [],
+  "targets": [
+    {
+      "kind": [
+        "lib"
+      ],
+      "crate_types": [
+        "lib"
+      ],
+      "name": "example-lib",
+      "src_path": "/home/muhuk/Documents/code/example-lib/src/lib.rs",
+      "edition": "2018"
+    }
+  ],
+  "features": null,
+  "manifest_path": "/home/muhuk/Documents/code/example-lib/Cargo.toml",
+  "metadata": null,
+  "authors": [
+    "Atamert Ölçgen <muhuk@muhuk.com>"
+  ],
+  "categories": [],
+  "keywords": [],
+  "readme": null,
+  "repository": null,
+  "edition": "2018",
+  "links": null
+}

--- a/test-resources/example-no-edition.json
+++ b/test-resources/example-no-edition.json
@@ -1,0 +1,34 @@
+{
+  "name": "example-no-edition",
+  "version": "0.1.0",
+  "id": "example-no-edition 0.1.0 (path+file:///home/muhuk/Documents/code/example-no-edition)",
+  "license": null,
+  "license_file": null,
+  "description": null,
+  "source": null,
+  "dependencies": [],
+  "targets": [
+    {
+      "kind": [
+        "lib"
+      ],
+      "crate_types": [
+        "lib"
+      ],
+      "name": "example-no-edition",
+      "src_path": "/home/muhuk/Documents/code/example-no-edition/src/lib.rs",
+      "edition": "2018"
+    }
+  ],
+  "features": null,
+  "manifest_path": "/home/muhuk/Documents/code/example-no-edition/Cargo.toml",
+  "metadata": null,
+  "authors": [
+    "Atamert Ölçgen <muhuk@muhuk.com>"
+  ],
+  "categories": [],
+  "keywords": [],
+  "readme": null,
+  "repository": null,
+  "links": null
+}


### PR DESCRIPTION
- Print a warning message if `--enable-edition-2018` is specified AND the manifest specifies `edition = "2018"`.
- Refactor manifest reading.  See `Manifest`, `Target` & `Edition`. 
- Add unit tests for manifest reading.