### PR TITLE
Edition 2018 graph with dependencies

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     NoTargetProvided(Vec<String>),
     InvalidManifest(String),
     Syntax(String),
+    Graph(String),
 }
 
 impl fmt::Display for Error {
@@ -35,6 +36,7 @@ impl fmt::Display for Error {
             ),
             Error::InvalidManifest(error) => write!(f, "{}", error),
             Error::Syntax(error) => write!(f, "Failed to parse: {}", error),
+            Error::Graph(error) => write!(f, "Graph error: {}", error),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn run_2018(args: &Arguments, manifest: &Manifest) -> Result<(), Error> {
     eprintln!("{}", "Warning: Edition 2018 support is unstable.".red());
 
     let ignored_files = build_scripts;
-    let graph: Graph = analysis::build_graph(target, &ignored_files)?;
+    let graph: Graph = analysis::build_graph(Edition::E2018, target, &ignored_files)?;
     match args.command {
         Command::Graph { .. } => graph_printer::print(&graph, include_orphans),
         Command::Tree => tree_printer::print(&graph, include_orphans),

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use manifest::{Edition, Manifest, Target};
 
 use ng::analysis;
 use ng::graph::Graph;
+use ng::graph_printer;
 use ng::tree_printer;
 
 use printer::Config as PrinterConfig;
@@ -80,20 +81,11 @@ fn run_2018(args: &Arguments, manifest: &Manifest) -> Result<(), Error> {
 
     eprintln!("{}", "Warning: Edition 2018 support is unstable.".red());
 
+    let ignored_files = build_scripts;
+    let graph: Graph = analysis::build_graph(target, &ignored_files)?;
     match args.command {
-        Command::Graph { .. } => {
-            eprintln!(
-                "\n{}\n{}",
-                "graph is not implemented for Edition 2018 yet.".red(),
-                "Try removing --enable-edition-2018".yellow()
-            );
-            Ok(())
-        }
-        Command::Tree => {
-            let ignored_files = &build_scripts;
-            let graph: Graph = analysis::build_graph(target, ignored_files)?;
-            tree_printer::print(&graph, include_orphans)
-        }
+        Command::Graph { .. } => graph_printer::print(&graph, include_orphans),
+        Command::Tree => tree_printer::print(&graph, include_orphans),
     }
 }
 

--- a/src/ng.rs
+++ b/src/ng.rs
@@ -1,4 +1,5 @@
 //! Temporary namespace to host the new graph based implementation.
 pub mod analysis;
 pub mod graph;
+pub mod graph_printer;
 pub mod tree_printer;

--- a/src/ng/analysis.rs
+++ b/src/ng/analysis.rs
@@ -92,10 +92,7 @@ pub fn build_graph<'a>(
             NodeId::from(0 as u32),
         );
 
-        builder
-            .graph_builder
-            .build()
-            .map_err(|e| Error::Syntax(format!("{:?}", e)))
+        Ok(builder.graph_builder.build())
     })
 }
 

--- a/src/ng/analysis.rs
+++ b/src/ng/analysis.rs
@@ -46,9 +46,11 @@ impl<'a> Builder<'a> {
 
         match use_tree.kind {
             UseTreeKind::Simple(alias, ..) => match alias {
-                // TODO: Add support for aliased imports.
-                //       eg: `use foo as bar`.
-                Some(_alias) => unimplemented!(),
+                Some(_alias) => {
+                    // TODO: Add support for aliased imports.
+                    //       eg: `use foo as bar`.
+                    eprintln!("Aliasing of modules is not yet supported by cargo-modules.  This use will be ignored: {:?}", &use_tree);
+                }
                 None => self.graph_builder.add_use(&self.path_str(), new_prefix),
             },
             UseTreeKind::Nested(ref children) => {

--- a/src/ng/graph.rs
+++ b/src/ng/graph.rs
@@ -487,35 +487,6 @@ mod tests {
         assert_eq!(3, graph.edge_count());
     }
 
-    // FIXME: Find some way to figure out whether a module member exists or
-    // not.
-    //
-    // #[test]
-    // fn add_use_requires_both_modules_to_be_defined() {
-    //     {
-    //         let mut builder = GraphBuilder::new(Edition::E2018);
-    //         builder.add_crate_root("foo");
-    //         builder.add_mod("foo", "bar", Visibility::Public, None);
-    //         builder.add_use("foo::bar", String::from("foo::baz"));
-    //         assert_eq!(
-    //             Some(GraphError::UnknownModule(String::from("foo::baz"))),
-    //             builder.build().err()
-    //         );
-    //     }
-    //     {
-    //         let mut builder = GraphBuilder::new(Edition::E2018);
-    //         builder.add_crate_root("foo");
-    //         builder.add_mod("foo", "bar", Visibility::Private, None);
-    //         builder.add_use("foo::bar", String::from("foo::baz"));
-    //         builder.add_use("foo::bar", String::from("foo::fubar"));
-    //         builder.add_mod("foo", "baz", Visibility::Private, None);
-    //         assert_eq!(
-    //             Some(GraphError::UnknownModule(String::from("foo::fubar"))),
-    //             builder.build().err()
-    //         );
-    //     }
-    // }
-
     #[test]
     fn add_use_recognizes_wildcard_imports() {
         let mut builder = GraphBuilder::new(Edition::E2018);

--- a/src/ng/graph.rs
+++ b/src/ng/graph.rs
@@ -280,7 +280,7 @@ impl GraphBuilder {
         } else {
             match self.find_parent(module) {
                 Some(parent) => self.find_root(parent),
-                None => unreachable!("Module {} is without a parent", module.name()),
+                None => unreachable!("No root can be found for module {}.", module.name()),
             }
         }
     }

--- a/src/ng/graph.rs
+++ b/src/ng/graph.rs
@@ -226,6 +226,10 @@ impl Module {
         &self.path[self.name_ridx..]
     }
 
+    pub fn is_orphan(&self) -> bool {
+        self.visibility.is_none()
+    }
+
     pub fn is_root(&self) -> bool {
         self.is_root
     }

--- a/src/ng/graph.rs
+++ b/src/ng/graph.rs
@@ -185,13 +185,13 @@ impl GraphBuilder {
         self.graph.nodes().find(|m| m.path() == path)
     }
 
+    // TODO: Don't bash on existing dependency.
+    // TODO: Actually add uses (see analysis.rs)
+    // TODO: Support self & super prefixed imports (E2015)
+    // TODO: Support crate prefixed imports (E2018)
     fn add_dependency(&mut self, from: Module, use_: &str) -> Result<(), GraphError> {
         match self.find(use_) {
             Some(to) => {
-                // TODO: Don't bash on existing dependency.
-                // TODO: Actually add uses (see analysis.rs)
-                // TODO: Support self & super prefixed imports (E2015)
-                // TODO: Support crate prefixed imports (E2018)
                 assert!(self
                     .graph
                     .add_edge(from, to, Edge::Dependency(Dependency::module()))

--- a/src/ng/graph.rs
+++ b/src/ng/graph.rs
@@ -189,6 +189,9 @@ impl GraphBuilder {
         match self.find(use_) {
             Some(to) => {
                 // TODO: Don't bash on existing dependency.
+                // TODO: Actually add uses (see analysis.rs)
+                // TODO: Support self & super prefixed imports (E2015)
+                // TODO: Support crate prefixed imports (E2018)
                 assert!(self
                     .graph
                     .add_edge(from, to, Edge::Dependency(Dependency::module()))

--- a/src/ng/graph.rs
+++ b/src/ng/graph.rs
@@ -78,6 +78,10 @@ impl Dependency {
             referred_members,
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        !self.refers_to_all && !self.refers_to_mod && self.referred_members.is_empty()
+    }
 }
 
 impl Add for Dependency {

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -98,7 +98,7 @@ fn format_hierarchy(from: Module, to: Module, edge: &Edge) -> Option<String> {
 }
 
 fn print_node(module: Module) {
-    let (color, fillcolor): (&str, &str) = match module.visibility() {
+    let (color, fill_color): (&str, &str) = match module.visibility() {
         Some(Visibility::Public) => ("green4", "greenyellow"),
         Some(Visibility::Private) => ("darkgoldenrod", "khaki1"),
         None => ("firebrick4", "rosybrown1"), // Module is orphaned
@@ -109,6 +109,6 @@ fn print_node(module: Module) {
         module.name(),
         color,
         color,
-        fillcolor
+        fill_color
     );
 }

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -1,11 +1,15 @@
 use error::Error;
-use ng::graph::{Graph, Module};
+use ng::graph::{Graph, Module, Visibility};
+use std::iter::repeat;
 
 pub fn print(graph: &Graph, include_orphans: bool) -> Result<(), Error> {
+    let mut indent: usize = 0;
     let root_node: Module = find_root_module(&graph)?;
 
     println!("digraph {{\n\tlabel=\"{}\";", root_node.name());
-    // TODO: rest of the graph comes here.
+    indent += 4;
+    print_nodes(&graph, include_orphans, indent)?;
+
     println!("}}");
     Ok(())
 }
@@ -17,4 +21,24 @@ fn find_root_module(graph: &Graph) -> Result<Module, Error> {
         (Some(module), 0) => Ok(module),
         (Some(_), _) => Err(Error::Graph("There are multiple root modules.".to_owned())),
     }
+}
+
+fn print_nodes(graph: &Graph, include_orphans: bool, indent: usize) -> Result<(), Error> {
+    let indent_str: String = repeat(' ').take(indent).collect();
+    for module in graph.nodes() {
+        let node_color: String = (match module.visibility() {
+            Some(Visibility::Public) => "green",
+            Some(Visibility::Private) => "gold",
+            None => "red",
+        })
+        .to_owned();
+        println!(
+            "{}\"{}\" [label=\"{}\", color={}]",
+            indent_str,
+            module.path(),
+            module.name(),
+            node_color
+        );
+    }
+    Ok(())
 }

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -6,9 +6,9 @@ pub fn print(graph: &Graph, include_orphans: bool) -> Result<(), Error> {
     let root_node: Module = find_root_module(&graph)?;
 
     println!(
-        "digraph {{\n{}label=\"{}\";\npad=0.4;",
-        indent_str,
-        root_node.name()
+        "digraph {{\n{}\n{}\n",
+        format!("{}label=\"{}\";", indent_str, root_node.name()),
+        format!("{}pad=0.4;", indent_str),
     );
 
     println!("{}// Modules", indent_str);

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -1,22 +1,28 @@
 use error::Error;
 use ng::graph::{Edge, Graph, Module, Visibility};
-use std::iter::repeat;
 
 pub fn print(graph: &Graph, include_orphans: bool) -> Result<(), Error> {
-    let mut indent: usize = 0;
+    let indent_str: &str = "    ";
     let root_node: Module = find_root_module(&graph)?;
 
-    println!("digraph {{\n\tlabel=\"{}\";", root_node.name());
-    indent += 4;
-    print_nodes(
-        graph.nodes().filter(|m| {
-            // All modules if include_orhans is true,
-            // else only non-orphaned modules.
-            include_orphans || !m.is_orphan()
-        }),
-        indent,
-    )?;
-    print_edges(graph.all_edges(), indent)?;
+    println!("digraph {{\n{}label=\"{}\";", indent_str, root_node.name());
+
+    println!("{}// Modules", indent_str);
+    for module in graph.nodes().filter(|m| {
+        // All modules if include_orhans is true,
+        // else only non-orphaned modules.
+        include_orphans || !m.is_orphan()
+    }) {
+        print!("{}", indent_str);
+        print_node(module);
+    }
+
+    println!("{}// Edges", indent_str);
+    for (from, to, edge) in graph.all_edges() {
+        print!("{}", indent_str);
+        print_edge(from, to, edge);
+    }
+
     println!("}}");
     Ok(())
 }
@@ -30,47 +36,25 @@ fn find_root_module(graph: &Graph) -> Result<Module, Error> {
     }
 }
 
-fn print_edges<'a, I>(edges: I, indent: usize) -> Result<(), Error>
-where
-    I: Iterator<Item = (Module, Module, &'a Edge)>,
-{
-    let indent_str: String = repeat(' ').take(indent).collect();
-    for (from, to, edge) in edges {
-        let edge_style: &str = match edge {
-            Edge::Child => "[weight=100, color=azure4]",
-            Edge::Dependency(_) => "[weight=90, color=darkviolet]",
-            Edge::Unconnected => "[weight=50, color=azure2]",
-        };
-        println!(
-            "{}\"{}\" -> \"{}\" {}",
-            indent_str,
-            from.path(),
-            to.path(),
-            edge_style
-        );
-    }
-    Ok(())
+fn print_edge(from: Module, to: Module, edge: &Edge) {
+    let edge_style: &str = match edge {
+        Edge::Child => "[weight=100, color=azure4]",
+        Edge::Dependency(_) => "[weight=90, color=darkviolet]",
+        Edge::Unconnected => "[weight=50, color=azure2]",
+    };
+    println!("\"{}\" -> \"{}\" {}", from.path(), to.path(), edge_style);
 }
 
-fn print_nodes<I>(nodes: I, indent: usize) -> Result<(), Error>
-where
-    I: Iterator<Item = Module>,
-{
-    let indent_str: String = repeat(' ').take(indent).collect();
-    println!("{}// Modules", indent_str);
-    for module in nodes {
-        let node_color: &str = match module.visibility() {
-            Some(Visibility::Public) => "green",
-            Some(Visibility::Private) => "gold",
-            None => "red", // Module is orphaned
-        };
-        println!(
-            "{}\"{}\" [label=\"{}\", color={}]",
-            indent_str,
-            module.path(),
-            module.name(),
-            node_color
-        );
-    }
-    Ok(())
+fn print_node(module: Module) {
+    let node_color: &str = match module.visibility() {
+        Some(Visibility::Public) => "green",
+        Some(Visibility::Private) => "gold",
+        None => "red", // Module is orphaned
+    };
+    println!(
+        "\"{}\" [label=\"{}\", color={}]",
+        module.path(),
+        module.name(),
+        node_color
+    );
 }

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -1,6 +1,20 @@
 use error::Error;
-use ng::graph::Graph;
+use ng::graph::{Graph, Module};
 
 pub fn print(graph: &Graph, include_orphans: bool) -> Result<(), Error> {
-    unimplemented!();
+    let root_node: Module = find_root_module(&graph)?;
+
+    println!("digraph {{\n\tlabel=\"{}\";", root_node.name());
+    // TODO: rest of the graph comes here.
+    println!("}}");
+    Ok(())
+}
+
+fn find_root_module(graph: &Graph) -> Result<Module, Error> {
+    let mut nodes = graph.nodes().filter(Module::is_root);
+    match (nodes.next(), nodes.count()) {
+        (None, _) => Err(Error::Graph("No root module found.".to_owned())),
+        (Some(module), 0) => Ok(module),
+        (Some(_), _) => Err(Error::Graph("There are multiple root modules.".to_owned())),
+    }
 }

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -5,7 +5,11 @@ pub fn print(graph: &Graph, include_orphans: bool) -> Result<(), Error> {
     let indent_str: &str = "    ";
     let root_node: Module = find_root_module(&graph)?;
 
-    println!("digraph {{\n{}label=\"{}\";", indent_str, root_node.name());
+    println!(
+        "digraph {{\n{}label=\"{}\";\npad=0.4;",
+        indent_str,
+        root_node.name()
+    );
 
     println!("{}// Modules", indent_str);
     for module in graph.nodes().filter(|m| {
@@ -53,7 +57,7 @@ fn format_dependency(from: Module, to: Module, edge: &Edge) -> Option<String> {
                 refers_to_mod,
                 referred_members,
             } => {
-                let color: &str = "darkviolet";
+                let color: &str = "azure3";
                 // TODO: Set the overall font size manually as well, instead
                 //       of relying on the default value.
                 let font_size: u8 = 10;
@@ -71,7 +75,7 @@ fn format_dependency(from: Module, to: Module, edge: &Edge) -> Option<String> {
                 }
 
                 Some(format!(
-                    "\"{}\" -> \"{}\" [weight=90, color={}, label=<<FONT POINT-SIZE=\"{}\" COLOR=\"{}\">{}</FONT>>]",
+                    "\"{}\" -> \"{}\" [weight=90, color={}, penwidth=2, label=<<FONT POINT-SIZE=\"{}\" COLOR=\"{}\">use {}</FONT>>]",
                     from.path(),
                     to.path(),
                     color,
@@ -86,23 +90,25 @@ fn format_dependency(from: Module, to: Module, edge: &Edge) -> Option<String> {
 
 fn format_hierarchy(from: Module, to: Module, edge: &Edge) -> Option<String> {
     (match edge.hierarchy {
-        Hierarchy::Child => Some("[weight=100, color=azure4]"),
-        Hierarchy::Orphan => Some("[weight=50, color=azure2]"),
+        Hierarchy::Child => Some("[weight=100, color=azure4, penwidth=3]"),
+        Hierarchy::Orphan => Some("[weight=50, color=firebrick4, penwidth=1]"),
         Hierarchy::None => None,
     })
     .map(|edge_style| format!("\"{}\" -> \"{}\" {}", from.path(), to.path(), edge_style))
 }
 
 fn print_node(module: Module) {
-    let node_color: &str = match module.visibility() {
-        Some(Visibility::Public) => "green",
-        Some(Visibility::Private) => "gold",
-        None => "red", // Module is orphaned
+    let (color, fillcolor): (&str, &str) = match module.visibility() {
+        Some(Visibility::Public) => ("green4", "greenyellow"),
+        Some(Visibility::Private) => ("darkgoldenrod", "khaki1"),
+        None => ("firebrick4", "rosybrown1"), // Module is orphaned
     };
     println!(
-        "\"{}\" [label=\"{}\", color={}]",
+        "\"{}\" [label=\"{}\", color={}, fontcolor={} style=filled, fillcolor={}]",
         module.path(),
         module.name(),
-        node_color
+        color,
+        color,
+        fillcolor
     );
 }

--- a/src/ng/graph_printer.rs
+++ b/src/ng/graph_printer.rs
@@ -1,0 +1,6 @@
+use error::Error;
+use ng::graph::Graph;
+
+pub fn print(graph: &Graph, include_orphans: bool) -> Result<(), Error> {
+    unimplemented!();
+}

--- a/test-resources/project/test-lib/src/bar.rs
+++ b/test-resources/project/test-lib/src/bar.rs
@@ -1,2 +1,8 @@
+#[allow(unused_imports)]
+use super::foo::{self, Foo};
+
+#[allow(unused_imports)]
+use crate::foo::foobar;
+
 #[derive(Default)]
 pub struct Bar;

--- a/test-resources/project/test-lib/src/foo.rs
+++ b/test-resources/project/test-lib/src/foo.rs
@@ -1,4 +1,5 @@
-mod foobar;
+pub mod foobar;
+
 mod phoo;
 
 use self::phoo::Phoo;

--- a/test-resources/project/test-lib/src/foo.rs
+++ b/test-resources/project/test-lib/src/foo.rs
@@ -2,6 +2,7 @@ pub mod foobar;
 
 mod phoo;
 
+// TODO: Fix this
 use self::phoo::Phoo;
 
 #[derive(Default)]

--- a/test-resources/project/test-lib/src/foo/foobar.rs
+++ b/test-resources/project/test-lib/src/foo/foobar.rs
@@ -1,4 +1,3 @@
-// TODO: Fix this
 use crate::bar::Bar;
 
 #[derive(Default)]


### PR DESCRIPTION
This patch adds dependencies to the graph (when `--enable-edition-2018` is present).

- `crate` is supported (see #29 )
- `self` & `super` prefixes are supported.
- Glob (`*`), module (`self`) & member imports are supported.
- I have changed graph configuration a little bit for increased readability. (feedback welcome)
- No E2015 support in `ng::graph::Graph` yet.

![modules-new](https://user-images.githubusercontent.com/40178/64061356-3b6a3200-cc0c-11e9-9d92-c801cccb73c0.png)

Please help review. 