### PR TITLE
Fix panic from libsyntax upgrade

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,9 +122,9 @@ fn run(args: &Arguments) -> Result<(), Error> {
         return run_2018(args, &manifest);
     }
 
-    let parse_session = ParseSess::new(source_map::FilePathMapping::empty());
-
     syntax::with_globals(Edition::Edition2015, || {
+        let parse_session = ParseSess::new(source_map::FilePathMapping::empty());
+
         let krate: Crate =
             match parse::parse_crate_from_file(target.src_path().as_ref(), &parse_session) {
                 Ok(_) if parse_session.span_diagnostic.has_errors() => Err(None),


### PR DESCRIPTION
Since the toolchain upgrade, `ParseSess::new` uses a global which is initialised by `syntax::with_globals`. I didn't dig too much into the change (it's a pretty big jump from the last `rustc-ap-syntax`).

Replicated with `cargo run tree` in this repo's root:

```
thread 'main' panicked at 'cannot access a scoped thread local variable without calling `set` first', /cargo/registry/src/github.com-1ecc6299db9ec823/scoped-tls-1.0.0/src/lib.rs:168:9
stack backtrace:
   0:     0x560a4127aeef - backtrace::backtrace::libunwind::trace::h441c4e337211a3c6
                               at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/libunwind.rs:88
   1:     0x560a4127aeef - backtrace::backtrace::trace_unsynchronized::h9442603d0e33b1d6
                               at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/mod.rs:66
   2:     0x560a4127aeef - std::sys_common::backtrace::_print_fmt::h02b474af5e13681c
                               at src/libstd/sys_common/backtrace.rs:61
   3:     0x560a4127aeef - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h8b60d15e42c92fe7
                               at src/libstd/sys_common/backtrace.rs:45
   4:     0x560a4129b5fc - core::fmt::write::h9392290131224cf6
                               at src/libcore/fmt/mod.rs:1030
   5:     0x560a412776c7 - std::io::Write::write_fmt::h69513f247a796657
                               at src/libstd/io/mod.rs:1412
   6:     0x560a4127d308 - std::sys_common::backtrace::_print::h7a48b9210e382046
                               at src/libstd/sys_common/backtrace.rs:48
   7:     0x560a4127d308 - std::sys_common::backtrace::print::h5b7f8746dd1057f2
                               at src/libstd/sys_common/backtrace.rs:33
   8:     0x560a4127d308 - std::panicking::default_hook::{{closure}}::haead9813b045d506
                               at src/libstd/panicking.rs:200
   9:     0x560a4127cff6 - std::panicking::default_hook::h1732881181d02f85
                               at src/libstd/panicking.rs:214
  10:     0x560a4127d9f5 - std::panicking::rust_panic_with_hook::h64c3c49fe843bb2a
                               at src/libstd/panicking.rs:477
  11:     0x560a40f4a785 - std::panicking::begin_panic::h0b4ffc97f3de4e7c
  12:     0x560a40f08532 - syntax_pos::hygiene::HygieneData::with::hdf86a35253083409
  13:     0x560a40f34485 - syntax::parse::ParseSess::with_span_handler::h21709054785987dc
  14:     0x560a40f343d1 - syntax::parse::ParseSess::new::h62ce7a41bd8347cd
  15:     0x560a40e37c15 - cargo_modules::run::h8957486589cb4611
                               at src/main.rs:125
  16:     0x560a40e38069 - cargo_modules::main::h63fabe2b0df83759
                               at src/main.rs:253
  17:     0x560a40eae7e0 - std::rt::lang_start::{{closure}}::h3294fe979b4119ab
                               at /rustc/34e82a7b793a6cdd27df762bf46bab8cdc92b14a/src/libstd/rt.rs:64
  18:     0x560a4127d423 - std::rt::lang_start_internal::{{closure}}::h9969da47b23a9f14
                               at src/libstd/rt.rs:49
  19:     0x560a4127d423 - std::panicking::try::do_call::h1375b0be74a84b29
                               at src/libstd/panicking.rs:296
  20:     0x560a41283e7a - __rust_maybe_catch_panic
                               at src/libpanic_unwind/lib.rs:80
  21:     0x560a4127dfad - std::panicking::try::h27213456d5efd24a
                               at src/libstd/panicking.rs:275
  22:     0x560a4127dfad - std::panic::catch_unwind::heb1a3baf7f3406c0
                               at src/libstd/panic.rs:394
  23:     0x560a4127dfad - std::rt::lang_start_internal::h1945375dd082beed
                               at src/libstd/rt.rs:48
  24:     0x560a40eae7b9 - std::rt::lang_start::h2742988df68665b7
                               at /rustc/34e82a7b793a6cdd27df762bf46bab8cdc92b14a/src/libstd/rt.rs:64
  25:     0x560a40e399ba - main
  26:     0x7f7fd2b72b97 - __libc_start_main
  27:     0x560a40e0c4fa - _start
  28:                0x0 - <unknown>
```