### PR TITLE
fix: rename 'Dashed' line style to 'dashed'

### DIFF
--- a/src/theme/graph.rs
+++ b/src/theme/graph.rs
@@ -101,7 +101,7 @@ impl fmt::Display for Stroke {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             Self::Solid => "solid",
-            Self::Dashed => "Dashed",
+            Self::Dashed => "dashed",
         };
         write!(f, "{}", name)
     }

--- a/tests/snapshots/generate_graph__github_issue_79__github_issue_79.snap
+++ b/tests/snapshots/generate_graph__github_issue_79__github_issue_79.snap
@@ -47,11 +47,11 @@ digraph {
     "github_issue_79" -> "github_issue_79::a" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_79::a" -> "github_issue_79::a::b" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
     "github_issue_79::a" -> "github_issue_79::a::d" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_79::a::d" -> "github_issue_79::a::d::e" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a" -> "github_issue_79::a::d" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
-    "github_issue_79::a" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "github_issue_79::a" -> "github_issue_79::a::d" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
+    "github_issue_79::a" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
 
 }
 

--- a/tests/snapshots/generate_graph__github_issue_80__with_tests__github_issue_80.snap
+++ b/tests/snapshots/generate_graph__github_issue_80__with_tests__github_issue_80.snap
@@ -56,12 +56,12 @@ digraph {
     "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
     "github_issue_80" -> "github_issue_80::only_exists_with_test" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80::only_exists_with_test" -> "github_issue_80::only_exists_with_test::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80::only_exists_with_test" -> "github_issue_80::only_exists_with_test::OnlyExistsWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
 
 }
 

--- a/tests/snapshots/generate_graph__github_issue_80__without_tests__github_issue_80.snap
+++ b/tests/snapshots/generate_graph__github_issue_80__without_tests__github_issue_80.snap
@@ -56,12 +56,12 @@ digraph {
     "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
     "github_issue_80" -> "github_issue_80::only_exists_without_test" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
 
 }
 

--- a/tests/snapshots/generate_graph__with_uses__smoke.snap
+++ b/tests/snapshots/generate_graph__with_uses__smoke.snap
@@ -72,7 +72,7 @@ digraph {
     "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
     "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge

--- a/tests/snapshots/generate_graph__with_uses_with_externs__smoke.snap
+++ b/tests/snapshots/generate_graph__with_uses_with_externs__smoke.snap
@@ -72,7 +72,7 @@ digraph {
     "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="Dashed"]; // "uses" edge
+    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
     "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
     "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge


### PR DESCRIPTION
This commit fixes the graphviz warning
`Warning: gvrender_set_style: unsupported style Dashed - ignoring`
and makes the dashed lines render as real dashed lines.