### PR TITLE
Ignore use edges in layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please make sure to add your changes to the appropriate categories:
 ### Changed
 
 - Updated to latest crate dependencies.
+- Made graph layout algorithm ignore `"uses"` edges in constraint calculation.
 
 ### Deprecated
 

--- a/src/printer/graph.rs
+++ b/src/printer/graph.rs
@@ -155,23 +155,29 @@ impl Printer {
             let edge = &graph[edge_idx];
             let (source_idx, target_idx) = graph.edge_endpoints(edge_idx).unwrap();
 
-            let source_id = graph[source_idx].path.join("::");
-            let target_id = graph[target_idx].path.join("::");
+            let source = graph[source_idx].path.join("::");
+            let target = graph[target_idx].path.join("::");
 
             let kind = edge.kind.display_name();
 
             let label = self.edge_label(edge);
             let attributes = self.edge_attributes(edge);
 
+            let constraint = match edge.kind {
+                EdgeKind::Uses => "[constraint=false]",
+                EdgeKind::Owns => "[constraint=true]",
+            };
+
             writeln!(
                 f,
-                r#"{i}{source:?} -> {target:?} [label={label:?}{attributes}]; // {kind:?} edge"#,
+                r#"{i}{source:?} -> {target:?} [label={label:?}{attributes}] {constraint}; // {kind:?} edge"#,
                 i = INDENTATION,
-                source = source_id,
-                target = target_id,
+                source = source,
+                target = target,
                 label = label,
                 attributes = attributes,
                 kind = kind,
+                constraint = constraint
             )?;
         }
 

--- a/tests/snapshots/generate_graph__colors__ansi__smoke.snap
+++ b/tests/snapshots/generate_graph__colors__ansi__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -66,33 +65,33 @@ digraph {
     "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
     "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__colors__plain__smoke.snap
+++ b/tests/snapshots/generate_graph__colors__plain__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -66,33 +65,33 @@ digraph {
     "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
     "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__colors__truecolor__smoke.snap
+++ b/tests/snapshots/generate_graph__colors__truecolor__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -66,33 +65,33 @@ digraph {
     "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
     "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__github_issue_79__github_issue_79.snap
+++ b/tests/snapshots/generate_graph__github_issue_79__github_issue_79.snap
@@ -43,14 +43,14 @@ digraph {
     "github_issue_79::a::d" [label="pub mod|a::d", fillcolor="#81c169"]; // "mod" node
     "github_issue_79::a::d::e" [label="pub(self) mod|a::d::e", fillcolor="#db5367"]; // "mod" node
 
-    "github_issue_79" -> "github_issue_79::a" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a" -> "github_issue_79::a::b" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "github_issue_79::a" -> "github_issue_79::a::d" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a::d" -> "github_issue_79::a::d::e" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_79::a" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "github_issue_79::a" -> "github_issue_79::a::d" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
+    "github_issue_79" -> "github_issue_79::a" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_79::a" -> "github_issue_79::a::b" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_79::a::b" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_79::a" -> "github_issue_79::a::d" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_79::a::d" -> "github_issue_79::a::d::e" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_79::a" -> "github_issue_79::a::b::c" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_79::a" -> "github_issue_79::a::d" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
 
 }
 

--- a/tests/snapshots/generate_graph__github_issue_80__with_tests__github_issue_80.snap
+++ b/tests/snapshots/generate_graph__github_issue_80__with_tests__github_issue_80.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -49,19 +48,19 @@ digraph {
     "github_issue_80::only_exists_with_test::Placebo" [label="pub struct|only_exists_with_test::Placebo", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::only_exists_with_test::OnlyExistsWithTest" [label="pub struct|only_exists_with_test::OnlyExistsWithTest", fillcolor="#81c169"]; // "struct" node
 
-    "github_issue_80" -> "github_issue_80::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::OnlyExistsWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::imported" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::imported" -> "github_issue_80::imported::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "github_issue_80" -> "github_issue_80::only_exists_with_test" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::only_exists_with_test" -> "github_issue_80::only_exists_with_test::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::only_exists_with_test" -> "github_issue_80::only_exists_with_test::OnlyExistsWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
+    "github_issue_80" -> "github_issue_80::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::OnlyExistsWithTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::imported" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::imported" -> "github_issue_80::imported::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_80" -> "github_issue_80::only_exists_with_test" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::only_exists_with_test" -> "github_issue_80::only_exists_with_test::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::only_exists_with_test" -> "github_issue_80::only_exists_with_test::OnlyExistsWithTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithTest" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
 
 }
 

--- a/tests/snapshots/generate_graph__github_issue_80__without_tests__github_issue_80.snap
+++ b/tests/snapshots/generate_graph__github_issue_80__without_tests__github_issue_80.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -49,19 +48,19 @@ digraph {
     "github_issue_80::only_exists_without_test::Placebo" [label="pub struct|only_exists_without_test::Placebo", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::only_exists_without_test::OnlyExistsWithoutTest" [label="pub struct|only_exists_without_test::OnlyExistsWithoutTest", fillcolor="#81c169"]; // "struct" node
 
-    "github_issue_80" -> "github_issue_80::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::imported" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::imported" -> "github_issue_80::imported::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "github_issue_80" -> "github_issue_80::only_exists_without_test" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::Placebo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
+    "github_issue_80" -> "github_issue_80::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::imported" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::imported" -> "github_issue_80::imported::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_80" -> "github_issue_80::only_exists_without_test" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
 
 }
 

--- a/tests/snapshots/generate_graph__with_orphans__smoke.snap
+++ b/tests/snapshots/generate_graph__with_orphans__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -68,35 +67,35 @@ digraph {
     "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
     "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::orphans" -> "smoke::orphans::bar" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::orphans" -> "smoke::orphans::foo" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::orphans" -> "smoke::orphans::bar" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::orphans" -> "smoke::orphans::foo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__with_tests__smoke.snap
+++ b/tests/snapshots/generate_graph__with_tests__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -67,34 +66,34 @@ digraph {
     "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
     "smoke::tests" [label="pub(crate) mod|tests", fillcolor="#f8c04c"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::tests" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::tests" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__with_types__smoke.snap
+++ b/tests/snapshots/generate_graph__with_types__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -86,53 +85,53 @@ digraph {
     "smoke::visibility::dummy::fns::pub_super" [label="pub(super) fn|visibility::dummy::fns::pub_super", fillcolor="#fe9454"]; // "fn" node
     "smoke::visibility::dummy::fns::pub_private" [label="pub(self) fn|visibility::dummy::fns::pub_private", fillcolor="#db5367"]; // "fn" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubPublic" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubCrate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubModule" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubSuper" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubPrivate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubPublic" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubCrate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubModule" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubSuper" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubPrivate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubPublic" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubCrate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubModule" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubSuper" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubPrivate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubPublic" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubCrate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubModule" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubSuper" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::structs" -> "smoke::visibility::dummy::structs::PubPrivate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubPublic" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubCrate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubModule" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubSuper" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::enums" -> "smoke::visibility::dummy::enums::PubPrivate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubPublic" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubCrate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubModule" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubSuper" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::unions" -> "smoke::visibility::dummy::unions::PubPrivate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::fns" -> "smoke::visibility::dummy::fns::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__with_uses__smoke.snap
+++ b/tests/snapshots/generate_graph__with_uses__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -66,34 +65,34 @@ digraph {
     "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
     "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 

--- a/tests/snapshots/generate_graph__with_uses_with_externs__smoke.snap
+++ b/tests/snapshots/generate_graph__with_uses_with_externs__smoke.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/generate_graph.rs
 expression: output
-
 ---
 STDERR:
 
@@ -66,34 +65,34 @@ digraph {
     "smoke::visibility::dummy::unions" [label="pub(self) mod|smoke::visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
     "smoke::visibility::dummy::fns" [label="pub(self) mod|smoke::visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
 
-    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"]; // "uses" edge
-    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"]; // "owns" edge
-    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"]; // "owns" edge
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_0" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle" -> "smoke::uses::cycle::node_1" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses::cycle::node_1" -> "smoke::uses::cycle::node_1::node_2" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::ipsum" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::dolor" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor" -> "smoke::hierarchy::lorem::dolor::sit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::dolor::sit" -> "smoke::hierarchy::lorem::dolor::sit::amet" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem" -> "smoke::hierarchy::lorem::consectetur" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur" -> "smoke::hierarchy::lorem::consectetur::adipiscing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy::lorem::consectetur::adipiscing" -> "smoke::hierarchy::lorem::consectetur::adipiscing::elit" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }
 


### PR DESCRIPTION
This PR makes dot/graphviz's engine ignore "uses" edges when layouting the graph.