### PR TITLE
Support for use-trees in `--focus-on`, i.e. "foo:bar::{self, baz, blee::*}"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Added
 
-- n/a
+- Support for accepting a full use-tree (e.g. `foo:bar::{self, baz, blee::*}`), instead of just simple paths.
 
 ### Changed
 

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -33,3 +33,24 @@ impl fmt::Display for EdgeKind {
 pub struct Edge {
     pub kind: EdgeKind,
 }
+
+impl Edge {
+    pub fn merge_with(&mut self, other: &Edge) {
+        match (self.kind, other.kind) {
+            (EdgeKind::Uses, EdgeKind::Uses) => {
+                self.kind = EdgeKind::Uses;
+            }
+            (EdgeKind::Uses, EdgeKind::Owns)
+            | (EdgeKind::Owns, EdgeKind::Uses)
+            | (EdgeKind::Owns, EdgeKind::Owns) => {
+                self.kind = EdgeKind::Owns;
+            }
+        }
+    }
+
+    pub fn merged_with(&self, other: &Edge) -> Self {
+        let mut clone = self.clone();
+        clone.merge_with(other);
+        clone
+    }
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -30,12 +30,13 @@ pub mod graph {
 
     #[derive(StructOpt, Clone, PartialEq, Eq, Debug)]
     pub struct Options {
-        /// Focus the graph on a particular path's environment.
+        /// Focus the graph on a particular path or use-tree's environment,
+        /// e.g. "foo:bar::{self, baz, blee::*}".
         #[structopt(long = "focus-on")]
         pub focus_on: Option<String>,
 
         /// The maximum depth of the generated graph
-        /// relative to the node selected by '--focus-on'.
+        /// relative to the crate's root node, or nodes selected by '--focus-on'.
         #[structopt(long = "max-depth")]
         pub max_depth: Option<usize>,
 

--- a/src/printer/graph.rs
+++ b/src/printer/graph.rs
@@ -51,8 +51,9 @@ impl Printer {
         start_node_idx: NodeIndex,
     ) -> Result<(), anyhow::Error> {
         let root_node = &graph[start_node_idx];
-        let crate_name = root_node.display_name();
-        let layout_name = &self.options.layout[..];
+        let label = root_node.display_path();
+        let layout = &self.options.layout[..];
+        let i = INDENTATION;
 
         writeln!(f, "digraph {{")?;
 
@@ -78,9 +79,6 @@ impl Printer {
             {i}    fontsize="36",
             {i}];
             "#,
-            i = INDENTATION,
-            label = crate_name,
-            layout = layout_name,
         )?;
 
         writeln!(f)?;
@@ -95,7 +93,6 @@ impl Printer {
             {i}    style="filled",
             {i}];
             "#,
-            i = INDENTATION,
         )?;
 
         writeln!(f)?;
@@ -108,7 +105,6 @@ impl Printer {
             {i}    fontsize="10",
             {i}];
             "#,
-            i = INDENTATION,
         )?;
 
         writeln!(f)?;
@@ -136,14 +132,11 @@ impl Printer {
             let label = self.node_label(node)?;
             let attributes = self.node_attributes(node);
 
+            let i = INDENTATION;
+
             writeln!(
                 f,
                 r#"{i}{id:?} [label={label:?}{attributes}]; // {kind:?} node"#,
-                i = INDENTATION,
-                id = id,
-                label = label,
-                attributes = attributes,
-                kind = kind,
             )?;
         }
 
@@ -168,16 +161,11 @@ impl Printer {
                 EdgeKind::Owns => "[constraint=true]",
             };
 
+            let i = INDENTATION;
+
             writeln!(
                 f,
                 r#"{i}{source:?} -> {target:?} [label={label:?}{attributes}] {constraint}; // {kind:?} edge"#,
-                i = INDENTATION,
-                source = source,
-                target = target,
-                label = label,
-                attributes = attributes,
-                kind = kind,
-                constraint = constraint
             )?;
         }
 

--- a/tests/generate_graph.rs
+++ b/tests/generate_graph.rs
@@ -366,6 +366,49 @@ mod with_uses_with_externs_with_sysroot {
     );
 }
 
+mod focus_on {
+    mod simple_path {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --focus-on \"smoke::visibility::dummy\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+    mod glob_path {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --focus-on \"smoke::visibility::*\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+    mod self_path {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --focus-on \"smoke::visibility::dummy::{self}\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+    mod tree {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --focus-on \"smoke::visibility::{dummy, hierarchy}\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+}
+
 mod max_depth {
     mod depth_0 {
         test_cmd!(

--- a/tests/generate_graph.rs
+++ b/tests/generate_graph.rs
@@ -366,6 +366,41 @@ mod with_uses_with_externs_with_sysroot {
     );
 }
 
+mod max_depth {
+    mod depth_0 {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --max-depth 0",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+
+    mod depth_1 {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --max-depth 1",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+
+    mod depth_2 {
+        test_cmd!(
+            args: "generate graph \
+                    --with-uses \
+                    --max-depth 2",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+}
+
 mod github_issue_79 {
     test_cmd!(
         args: "generate graph \

--- a/tests/generate_tree.rs
+++ b/tests/generate_tree.rs
@@ -324,6 +324,45 @@ mod github_issue_80 {
     }
 }
 
+mod focus_on {
+    mod simple_path {
+        test_cmd!(
+            args: "generate tree \
+                    --focus-on \"smoke::visibility::dummy\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+    mod glob_path {
+        test_cmd!(
+            args: "generate tree \
+                    --focus-on \"smoke::visibility::*\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+    mod self_path {
+        test_cmd!(
+            args: "generate tree \
+                    --focus-on \"smoke::visibility::dummy::{self}\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+    mod tree {
+        test_cmd!(
+            args: "generate tree \
+                    --focus-on \"smoke::visibility::{dummy, hierarchy}\"",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+}
+
 mod max_depth {
     mod depth_0 {
         test_cmd!(

--- a/tests/generate_tree.rs
+++ b/tests/generate_tree.rs
@@ -323,3 +323,35 @@ mod github_issue_80 {
         );
     }
 }
+
+mod max_depth {
+    mod depth_0 {
+        test_cmd!(
+            args: "generate tree \
+                    --max-depth 0",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+
+    mod depth_1 {
+        test_cmd!(
+            args: "generate tree \
+                    --max-depth 1",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+
+    mod depth_2 {
+        test_cmd!(
+            args: "generate tree \
+                    --max-depth 2",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: smoke
+        );
+    }
+}

--- a/tests/snapshots/generate_graph__focus_on__glob_path__smoke.snap
+++ b/tests/snapshots/generate_graph__focus_on__glob_path__smoke.snap
@@ -1,0 +1,67 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+    "smoke::visibility" [label="pub(crate) mod|visibility", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy" [label="pub(self) mod|visibility::dummy", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods" [label="pub(self) mod|visibility::dummy::mods", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_public" [label="pub mod|visibility::dummy::mods::pub_public", fillcolor="#81c169"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_crate" [label="pub(crate) mod|visibility::dummy::mods::pub_crate", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_module" [label="pub(in crate::visibility) mod|visibility::dummy::mods::pub_module", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_super" [label="pub(super) mod|visibility::dummy::mods::pub_super", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_private" [label="pub(self) mod|visibility::dummy::mods::pub_private", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::structs" [label="pub(self) mod|visibility::dummy::structs", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::enums" [label="pub(self) mod|visibility::dummy::enums", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
+
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+
+}
+

--- a/tests/snapshots/generate_graph__focus_on__self_path__smoke.snap
+++ b/tests/snapshots/generate_graph__focus_on__self_path__smoke.snap
@@ -1,0 +1,67 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+    "smoke::visibility" [label="pub(crate) mod|visibility", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy" [label="pub(self) mod|visibility::dummy", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods" [label="pub(self) mod|visibility::dummy::mods", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_public" [label="pub mod|visibility::dummy::mods::pub_public", fillcolor="#81c169"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_crate" [label="pub(crate) mod|visibility::dummy::mods::pub_crate", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_module" [label="pub(in crate::visibility) mod|visibility::dummy::mods::pub_module", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_super" [label="pub(super) mod|visibility::dummy::mods::pub_super", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_private" [label="pub(self) mod|visibility::dummy::mods::pub_private", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::structs" [label="pub(self) mod|visibility::dummy::structs", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::enums" [label="pub(self) mod|visibility::dummy::enums", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
+
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+
+}
+

--- a/tests/snapshots/generate_graph__focus_on__simple_path__smoke.snap
+++ b/tests/snapshots/generate_graph__focus_on__simple_path__smoke.snap
@@ -1,0 +1,67 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+    "smoke::visibility" [label="pub(crate) mod|visibility", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy" [label="pub(self) mod|visibility::dummy", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods" [label="pub(self) mod|visibility::dummy::mods", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_public" [label="pub mod|visibility::dummy::mods::pub_public", fillcolor="#81c169"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_crate" [label="pub(crate) mod|visibility::dummy::mods::pub_crate", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_module" [label="pub(in crate::visibility) mod|visibility::dummy::mods::pub_module", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_super" [label="pub(super) mod|visibility::dummy::mods::pub_super", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_private" [label="pub(self) mod|visibility::dummy::mods::pub_private", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::structs" [label="pub(self) mod|visibility::dummy::structs", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::enums" [label="pub(self) mod|visibility::dummy::enums", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
+
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+
+}
+

--- a/tests/snapshots/generate_graph__focus_on__tree__smoke.snap
+++ b/tests/snapshots/generate_graph__focus_on__tree__smoke.snap
@@ -1,0 +1,67 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+    "smoke::visibility" [label="pub(crate) mod|visibility", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy" [label="pub(self) mod|visibility::dummy", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods" [label="pub(self) mod|visibility::dummy::mods", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_public" [label="pub mod|visibility::dummy::mods::pub_public", fillcolor="#81c169"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_crate" [label="pub(crate) mod|visibility::dummy::mods::pub_crate", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_module" [label="pub(in crate::visibility) mod|visibility::dummy::mods::pub_module", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_super" [label="pub(super) mod|visibility::dummy::mods::pub_super", fillcolor="#fe9454"]; // "mod" node
+    "smoke::visibility::dummy::mods::pub_private" [label="pub(self) mod|visibility::dummy::mods::pub_private", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::structs" [label="pub(self) mod|visibility::dummy::structs", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::enums" [label="pub(self) mod|visibility::dummy::enums", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::unions" [label="pub(self) mod|visibility::dummy::unions", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility::dummy::fns" [label="pub(self) mod|visibility::dummy::fns", fillcolor="#db5367"]; // "mod" node
+
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::mods" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_public" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_crate" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_module" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_super" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy::mods" -> "smoke::visibility::dummy::mods::pub_private" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::structs" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::enums" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::unions" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility::dummy" -> "smoke::visibility::dummy::fns" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+
+}
+

--- a/tests/snapshots/generate_graph__max_depth__depth_0__smoke.snap
+++ b/tests/snapshots/generate_graph__max_depth__depth_0__smoke.snap
@@ -1,0 +1,43 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+
+
+}
+

--- a/tests/snapshots/generate_graph__max_depth__depth_1__smoke.snap
+++ b/tests/snapshots/generate_graph__max_depth__depth_1__smoke.snap
@@ -1,0 +1,52 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+    "smoke::orphans" [label="pub(crate) mod|orphans", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::uses" [label="pub(crate) mod|uses", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::hierarchy" [label="pub(crate) mod|hierarchy", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility" [label="pub(crate) mod|visibility", fillcolor="#f8c04c"]; // "mod" node
+
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+
+}
+

--- a/tests/snapshots/generate_graph__max_depth__depth_2__smoke.snap
+++ b/tests/snapshots/generate_graph__max_depth__depth_2__smoke.snap
@@ -1,0 +1,58 @@
+---
+source: tests/generate_graph.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="smoke",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "smoke" [label="crate|smoke", fillcolor="#5397c8"]; // "crate" node
+    "smoke::orphans" [label="pub(crate) mod|orphans", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::uses" [label="pub(crate) mod|uses", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::uses::cycle" [label="pub(self) mod|uses::cycle", fillcolor="#db5367"]; // "mod" node
+    "smoke::hierarchy" [label="pub(crate) mod|hierarchy", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::hierarchy::lorem" [label="pub(self) mod|hierarchy::lorem", fillcolor="#db5367"]; // "mod" node
+    "smoke::visibility" [label="pub(crate) mod|visibility", fillcolor="#f8c04c"]; // "mod" node
+    "smoke::visibility::dummy" [label="pub(self) mod|visibility::dummy", fillcolor="#db5367"]; // "mod" node
+
+    "smoke" -> "smoke::orphans" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::uses" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::uses::cycle" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::uses" -> "smoke::hierarchy" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "smoke" -> "smoke::hierarchy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::hierarchy" -> "smoke::hierarchy::lorem" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke" -> "smoke::visibility" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "smoke::visibility" -> "smoke::visibility::dummy" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+
+}
+

--- a/tests/snapshots/generate_tree__focus_on__glob_path__smoke.snap
+++ b/tests/snapshots/generate_tree__focus_on__glob_path__smoke.snap
@@ -1,0 +1,22 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+└── mod visibility: pub(crate)
+    └── mod dummy: pub(self)
+        ├── mod enums: pub(self)
+        ├── mod fns: pub(self)
+        ├── mod mods: pub(self)
+        │   ├── mod pub_crate: pub(crate)
+        │   ├── mod pub_module: pub(in crate::visibility)
+        │   ├── mod pub_private: pub(self)
+        │   ├── mod pub_public: pub
+        │   └── mod pub_super: pub(super)
+        ├── mod structs: pub(self)
+        └── mod unions: pub(self)
+

--- a/tests/snapshots/generate_tree__focus_on__self_path__smoke.snap
+++ b/tests/snapshots/generate_tree__focus_on__self_path__smoke.snap
@@ -1,0 +1,22 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+└── mod visibility: pub(crate)
+    └── mod dummy: pub(self)
+        ├── mod enums: pub(self)
+        ├── mod fns: pub(self)
+        ├── mod mods: pub(self)
+        │   ├── mod pub_crate: pub(crate)
+        │   ├── mod pub_module: pub(in crate::visibility)
+        │   ├── mod pub_private: pub(self)
+        │   ├── mod pub_public: pub
+        │   └── mod pub_super: pub(super)
+        ├── mod structs: pub(self)
+        └── mod unions: pub(self)
+

--- a/tests/snapshots/generate_tree__focus_on__simple_path__smoke.snap
+++ b/tests/snapshots/generate_tree__focus_on__simple_path__smoke.snap
@@ -1,0 +1,22 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+└── mod visibility: pub(crate)
+    └── mod dummy: pub(self)
+        ├── mod enums: pub(self)
+        ├── mod fns: pub(self)
+        ├── mod mods: pub(self)
+        │   ├── mod pub_crate: pub(crate)
+        │   ├── mod pub_module: pub(in crate::visibility)
+        │   ├── mod pub_private: pub(self)
+        │   ├── mod pub_public: pub
+        │   └── mod pub_super: pub(super)
+        ├── mod structs: pub(self)
+        └── mod unions: pub(self)
+

--- a/tests/snapshots/generate_tree__focus_on__tree__smoke.snap
+++ b/tests/snapshots/generate_tree__focus_on__tree__smoke.snap
@@ -1,0 +1,22 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+└── mod visibility: pub(crate)
+    └── mod dummy: pub(self)
+        ├── mod enums: pub(self)
+        ├── mod fns: pub(self)
+        ├── mod mods: pub(self)
+        │   ├── mod pub_crate: pub(crate)
+        │   ├── mod pub_module: pub(in crate::visibility)
+        │   ├── mod pub_private: pub(self)
+        │   ├── mod pub_public: pub
+        │   └── mod pub_super: pub(super)
+        ├── mod structs: pub(self)
+        └── mod unions: pub(self)
+

--- a/tests/snapshots/generate_tree__max_depth__depth_0__smoke.snap
+++ b/tests/snapshots/generate_tree__max_depth__depth_0__smoke.snap
@@ -1,0 +1,10 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+

--- a/tests/snapshots/generate_tree__max_depth__depth_1__smoke.snap
+++ b/tests/snapshots/generate_tree__max_depth__depth_1__smoke.snap
@@ -1,0 +1,14 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+├── mod hierarchy: pub(crate)
+├── mod orphans: pub(crate)
+├── mod uses: pub(crate)
+└── mod visibility: pub(crate)
+

--- a/tests/snapshots/generate_tree__max_depth__depth_2__smoke.snap
+++ b/tests/snapshots/generate_tree__max_depth__depth_2__smoke.snap
@@ -1,0 +1,17 @@
+---
+source: tests/generate_tree.rs
+expression: output
+---
+STDERR:
+
+STDOUT:
+
+crate smoke
+├── mod hierarchy: pub(crate)
+│   └── mod lorem: pub(self)
+├── mod orphans: pub(crate)
+├── mod uses: pub(crate)
+│   └── mod cycle: pub(self)
+└── mod visibility: pub(crate)
+    └── mod dummy: pub(self)
+


### PR DESCRIPTION
Fixes #141.