### PR TITLE
Make tree and graph data structures more generic

### DIFF
--- a/src/command/dependencies/command.rs
+++ b/src/command/dependencies/command.rs
@@ -45,8 +45,8 @@ impl Command {
                 TriColorDepthFirstSearch::new(&graph).run_from(crate_node_idx, &mut CycleDetector)
             {
                 assert!(cycle.len() >= 2);
-                let first = graph[cycle[0]].item.display_path(db);
-                let last = graph[*cycle.last().unwrap()].item.display_path(db);
+                let first = graph[cycle[0]].display_path(db);
+                let last = graph[*cycle.last().unwrap()].display_path(db);
                 let drawing = draw_cycle(&graph, cycle, db);
                 anyhow::bail!("Circular dependency between `{first}` and `{last}`.\n\n{drawing}");
             }
@@ -86,11 +86,11 @@ impl Command {
 fn draw_cycle(graph: &Graph<Node, Edge>, cycle: Vec<NodeIndex>, db: &RootDatabase) -> String {
     assert!(!cycle.is_empty());
 
-    let first = graph[cycle[0]].item.display_path(db);
+    let first = graph[cycle[0]].display_path(db);
     let mut drawing = format!("┌> {first}\n");
 
     for (i, node) in cycle[1..].iter().enumerate() {
-        let path = graph[*node].item.display_path(db);
+        let path = graph[*node].display_path(db);
         drawing += &format!("│  {:>width$}└─> {path}\n", "", width = i * 4);
     }
 

--- a/src/command/dependencies/command.rs
+++ b/src/command/dependencies/command.rs
@@ -10,7 +10,7 @@ use ra_ap_ide::RootDatabase;
 
 use crate::{
     analyzer::LoadOptions,
-    graph::{Graph, GraphBuilder},
+    graph::{Edge, Graph, GraphBuilder, Node},
 };
 
 use super::{
@@ -83,7 +83,7 @@ impl Command {
     }
 }
 
-fn draw_cycle(graph: &Graph, cycle: Vec<NodeIndex>, db: &RootDatabase) -> String {
+fn draw_cycle(graph: &Graph<Node, Edge>, cycle: Vec<NodeIndex>, db: &RootDatabase) -> String {
     assert!(!cycle.is_empty());
 
     let first = graph[cycle[0]].item.display_path(db);

--- a/src/command/dependencies/cycles/tri_color.rs
+++ b/src/command/dependencies/cycles/tri_color.rs
@@ -20,7 +20,7 @@ use std::{marker::PhantomData, ops::ControlFlow};
 use bitvec::vec::BitVec;
 use petgraph::graph::{IndexType, NodeIndex};
 
-use crate::graph::Graph as G;
+type G = crate::graph::Graph<crate::graph::Node, crate::graph::Edge>;
 
 struct BitSet<T> {
     vec: BitVec,

--- a/src/command/dependencies/filter.rs
+++ b/src/command/dependencies/filter.rs
@@ -59,7 +59,7 @@ impl<'a> Filter<'a> {
             .node_indices()
             .filter(|node_idx| {
                 let node = &graph[*node_idx];
-                let path = node.item.display_path(self.db);
+                let path = node.display_path(self.db);
                 analyzer::use_tree_matches_item_path(&use_tree, &path[..])
             })
             .collect();
@@ -103,7 +103,7 @@ impl<'a> Filter<'a> {
                 should_keep_node &= nodes_within_max_depth.contains(node_idx);
 
                 // Make sure the node's `moduledef` should be retained:
-                should_keep_node &= self.should_retain_moduledef(node.item.hir);
+                should_keep_node &= self.should_retain_moduledef(node.hir);
 
                 // Make sure the root node doesn't get dropped:
                 should_keep_node |= *node_idx == root_idx;

--- a/src/command/dependencies/filter.rs
+++ b/src/command/dependencies/filter.rs
@@ -17,7 +17,7 @@ use ra_ap_syntax::ast;
 
 use crate::{
     analyzer,
-    graph::{Edge, EdgeKind, Graph, GraphWalker, Node},
+    graph::{Edge, Graph, GraphWalker, Node, Relationship},
 };
 
 use super::options::Options;
@@ -125,7 +125,7 @@ impl<'a> Filter<'a> {
             let parent_owned_node = |node_idx| {
                 graph
                     .edges_directed(node_idx, Direction::Incoming)
-                    .find(|edge_ref| matches!(edge_ref.weight().kind, EdgeKind::Owns))
+                    .find(|edge_ref| matches!(edge_ref.weight().kind, Relationship::Owns))
                     .map(|edge_ref| edge_ref.source())
             };
 
@@ -187,7 +187,7 @@ impl<'a> Filter<'a> {
         if self.options.selection.no_uses {
             graph.retain_edges(|graph, edge_idx| {
                 let edge = &graph[edge_idx];
-                edge.kind == EdgeKind::Owns
+                edge.kind == Relationship::Owns
             });
         }
 
@@ -347,7 +347,7 @@ impl<'a> Filter<'a> {
         graph.filter_map(
             |_node_idx, node| Some(node.clone()),
             |_edge_idx, edge| {
-                if matches!(edge.kind, EdgeKind::Owns) {
+                if matches!(edge.kind, Relationship::Owns) {
                     Some(edge.clone())
                 } else {
                     None
@@ -387,7 +387,7 @@ impl<'a> Filter<'a> {
             // Walks from a node to its ascendants in the graph (i.e. super-items & dependents):
             let mut ascendants_walker = GraphWalker::new(petgraph::Direction::Incoming);
             ascendants_walker.walk_graph(graph, *start_node_idx, |edge, _node, depth| {
-                (edge.kind == EdgeKind::Owns) || (depth <= max_depth)
+                (edge.kind == Relationship::Owns) || (depth <= max_depth)
             });
             nodes_to_keep.extend(ascendants_walker.nodes_visited);
         }

--- a/src/command/dependencies/printer.rs
+++ b/src/command/dependencies/printer.rs
@@ -15,7 +15,7 @@ use ra_ap_ide::RootDatabase;
 
 use crate::{
     analyzer,
-    graph::{Edge, Graph, Node, Relationship},
+    graph::{Edge, Graph, Node},
     item::ItemVisibility,
 };
 
@@ -155,14 +155,14 @@ impl<'a> Printer<'a> {
             let source = graph[source_idx].display_path(self.db);
             let target = graph[target_idx].display_path(self.db);
 
-            let kind = edge.kind.display_name();
+            let kind = edge.display_name();
 
             let label = self.edge_label(edge);
             let attributes = self.edge_attributes(edge);
 
-            let constraint = match edge.kind {
-                Relationship::Uses => "[constraint=false]",
-                Relationship::Owns => "[constraint=true]",
+            let constraint = match edge {
+                Edge::Uses => "[constraint=false]",
+                Edge::Owns => "[constraint=true]",
             };
 
             let i = INDENTATION;
@@ -251,15 +251,15 @@ impl<'a> Printer<'a> {
     }
 
     fn edge_label(&self, edge: &Edge) -> String {
-        edge.kind.display_name().to_owned()
+        edge.display_name().to_owned()
     }
 
     fn edge_attributes(&self, edge: &Edge) -> String {
         let styles = edge_styles();
 
-        let style = match edge.kind {
-            Relationship::Uses { .. } => styles.uses,
-            Relationship::Owns => styles.owns,
+        let style = match edge {
+            Edge::Uses { .. } => styles.uses,
+            Edge::Owns => styles.owns,
         };
 
         format!(r#", color="{}", style="{}""#, style.color, style.stroke)

--- a/src/command/dependencies/printer.rs
+++ b/src/command/dependencies/printer.rs
@@ -44,7 +44,7 @@ impl<'a> Printer<'a> {
     pub fn fmt(
         &self,
         f: &mut dyn fmt::Write,
-        graph: &Graph,
+        graph: &Graph<Node, Edge>,
         start_node_idx: NodeIndex,
     ) -> Result<(), anyhow::Error> {
         let root_node = &graph[start_node_idx];
@@ -119,7 +119,7 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
-    fn fmt_nodes(&self, f: &mut dyn fmt::Write, graph: &Graph) -> fmt::Result {
+    fn fmt_nodes(&self, f: &mut dyn fmt::Write, graph: &Graph<Node, Edge>) -> fmt::Result {
         let mut lines: Vec<_> = graph
             .node_references()
             .map(|node_ref| {
@@ -147,7 +147,7 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
-    fn fmt_edges(&self, f: &mut dyn fmt::Write, graph: &Graph) -> fmt::Result {
+    fn fmt_edges(&self, f: &mut dyn fmt::Write, graph: &Graph<Node, Edge>) -> fmt::Result {
         let mut lines: Vec<_> = graph.edge_indices().map(|edge_idx| {
             let edge = &graph[edge_idx];
             let (source_idx, target_idx) = graph.edge_endpoints(edge_idx).unwrap();

--- a/src/command/dependencies/printer.rs
+++ b/src/command/dependencies/printer.rs
@@ -15,7 +15,7 @@ use ra_ap_ide::RootDatabase;
 
 use crate::{
     analyzer,
-    graph::{Edge, EdgeKind, Graph, Node},
+    graph::{Edge, Graph, Node, Relationship},
     item::ItemVisibility,
 };
 
@@ -161,8 +161,8 @@ impl<'a> Printer<'a> {
             let attributes = self.edge_attributes(edge);
 
             let constraint = match edge.kind {
-                EdgeKind::Uses => "[constraint=false]",
-                EdgeKind::Owns => "[constraint=true]",
+                Relationship::Uses => "[constraint=false]",
+                Relationship::Owns => "[constraint=true]",
             };
 
             let i = INDENTATION;
@@ -258,8 +258,8 @@ impl<'a> Printer<'a> {
         let styles = edge_styles();
 
         let style = match edge.kind {
-            EdgeKind::Uses { .. } => styles.uses,
-            EdgeKind::Owns => styles.owns,
+            Relationship::Uses { .. } => styles.uses,
+            Relationship::Owns => styles.owns,
         };
 
         format!(r#", color="{}", style="{}""#, style.color, style.stroke)

--- a/src/command/structure.rs
+++ b/src/command/structure.rs
@@ -8,3 +8,5 @@ pub(super) mod command;
 pub(super) mod filter;
 pub(crate) mod printer;
 pub(super) mod theme;
+
+type Node = crate::item::Item;

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,6 +16,7 @@ pub(crate) use self::{builder::GraphBuilder, walker::GraphWalker};
 pub type Graph<N, E> = StableGraph<N, E>;
 
 pub type Node = Item;
+pub type Edge = Relationship;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 pub enum Relationship {
@@ -40,9 +41,4 @@ impl fmt::Display for Relationship {
         };
         write!(f, "{name}")
     }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-pub struct Edge {
-    pub kind: Relationship,
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -13,7 +13,7 @@ mod walker;
 
 pub(crate) use self::{builder::GraphBuilder, walker::GraphWalker};
 
-pub type Graph = StableGraph<Node, Edge>;
+pub type Graph<N, E> = StableGraph<N, E>;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Node {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -15,16 +15,7 @@ pub(crate) use self::{builder::GraphBuilder, walker::GraphWalker};
 
 pub type Graph<N, E> = StableGraph<N, E>;
 
-#[derive(Clone, PartialEq, Debug)]
-pub struct Node {
-    pub item: Item,
-}
-
-impl Node {
-    pub fn new(item: Item) -> Self {
-        Self { item }
-    }
-}
+pub type Node = Item;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 pub enum EdgeKind {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -18,12 +18,12 @@ pub type Graph<N, E> = StableGraph<N, E>;
 pub type Node = Item;
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub enum EdgeKind {
+pub enum Relationship {
     Uses,
     Owns,
 }
 
-impl EdgeKind {
+impl Relationship {
     pub fn display_name(&self) -> &'static str {
         match self {
             Self::Uses => "uses",
@@ -32,7 +32,7 @@ impl EdgeKind {
     }
 }
 
-impl fmt::Display for EdgeKind {
+impl fmt::Display for Relationship {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             Self::Uses => "Uses",
@@ -44,5 +44,5 @@ impl fmt::Display for EdgeKind {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Edge {
-    pub kind: EdgeKind,
+    pub kind: Relationship,
 }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -14,7 +14,7 @@ use ra_ap_ide_db::{self as ide_db};
 use scopeguard::defer;
 
 use crate::{
-    graph::{Edge, EdgeKind, Graph, Node},
+    graph::{Edge, Graph, Node, Relationship},
     item::Item,
 };
 
@@ -30,7 +30,7 @@ pub struct GraphBuilder<'a> {
     krate: hir::Crate,
     graph: Graph<Node, Edge>,
     nodes: HashMap<hir::ModuleDef, NodeIndex>,
-    edges: HashMap<(NodeIndex, EdgeKind, NodeIndex), EdgeIndex>,
+    edges: HashMap<(NodeIndex, Relationship, NodeIndex), EdgeIndex>,
 }
 
 impl<'a> GraphBuilder<'a> {
@@ -90,7 +90,7 @@ impl<'a> GraphBuilder<'a> {
 
             for impl_item_idx in self.process_impl(impl_hir) {
                 let edge = Edge {
-                    kind: EdgeKind::Owns,
+                    kind: Relationship::Owns,
                 };
 
                 self.add_edge(impl_ty_idx, impl_item_idx, edge);
@@ -213,7 +213,7 @@ impl<'a> GraphBuilder<'a> {
                 };
 
                 let edge = Edge {
-                    kind: EdgeKind::Owns,
+                    kind: Relationship::Owns,
                 };
 
                 self.add_edge(node_idx, declaration_idx, edge);
@@ -723,7 +723,7 @@ impl<'a> GraphBuilder<'a> {
             };
 
             let edge = Edge {
-                kind: EdgeKind::Uses,
+                kind: Relationship::Uses,
             };
 
             self.add_edge(depender_idx, dependency_hir, edge);

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -89,11 +89,7 @@ impl<'a> GraphBuilder<'a> {
             let impl_ty_idx = *self.nodes.get(&impl_ty_hir).expect("impl type node");
 
             for impl_item_idx in self.process_impl(impl_hir) {
-                let edge = Edge {
-                    kind: Relationship::Owns,
-                };
-
-                self.add_edge(impl_ty_idx, impl_item_idx, edge);
+                self.add_edge(impl_ty_idx, impl_item_idx, Edge::Owns);
             }
         }
 
@@ -212,11 +208,7 @@ impl<'a> GraphBuilder<'a> {
                     continue;
                 };
 
-                let edge = Edge {
-                    kind: Relationship::Owns,
-                };
-
-                self.add_edge(node_idx, declaration_idx, edge);
+                self.add_edge(node_idx, declaration_idx, Edge::Owns);
             }
         }
 
@@ -722,11 +714,7 @@ impl<'a> GraphBuilder<'a> {
                 continue;
             };
 
-            let edge = Edge {
-                kind: Relationship::Uses,
-            };
-
-            self.add_edge(depender_idx, dependency_hir, edge);
+            self.add_edge(depender_idx, dependency_hir, Edge::Uses);
         }
     }
 
@@ -770,11 +758,11 @@ impl<'a> GraphBuilder<'a> {
             return None;
         }
 
-        let edge_name = edge.kind.display_name();
         let source_path = self.graph[source_idx].display_path(self.db);
         let target_path = self.graph[target_idx].display_path(self.db);
+        let edge_name = edge.display_name();
 
-        let edge_id = (source_idx, edge.kind, target_idx);
+        let edge_id = (source_idx, edge, target_idx);
 
         trace!("Adding edge: {source_path} --({edge_name})-> {target_path}...");
 

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -28,7 +28,7 @@ struct Dependency {
 pub struct GraphBuilder<'a> {
     db: &'a ide_db::RootDatabase,
     krate: hir::Crate,
-    graph: Graph,
+    graph: Graph<Node, Edge>,
     nodes: HashMap<hir::ModuleDef, NodeIndex>,
     edges: HashMap<(NodeIndex, EdgeKind, NodeIndex), EdgeIndex>,
 }
@@ -48,7 +48,7 @@ impl<'a> GraphBuilder<'a> {
         }
     }
 
-    pub fn build(mut self) -> anyhow::Result<(Graph, NodeIndex)> {
+    pub fn build(mut self) -> anyhow::Result<(Graph<Node, Edge>, NodeIndex)> {
         trace!("Scanning project...");
 
         defer! {

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -751,7 +751,7 @@ impl<'a> GraphBuilder<'a> {
             }
             None => {
                 // Otherwise try to add a node:
-                let node = Node::new(Item::new(module_def_hir));
+                let node = Item::new(module_def_hir);
                 let node_idx = self.graph.add_node(node);
                 self.nodes.insert(module_def_hir, node_idx);
 
@@ -770,9 +770,9 @@ impl<'a> GraphBuilder<'a> {
             return None;
         }
 
-        let source_path = self.graph[source_idx].item.display_path(self.db);
-        let target_path = self.graph[target_idx].item.display_path(self.db);
         let edge_name = edge.kind.display_name();
+        let source_path = self.graph[source_idx].display_path(self.db);
+        let target_path = self.graph[target_idx].display_path(self.db);
 
         let edge_id = (source_idx, edge.kind, target_idx);
 

--- a/src/graph/walker.rs
+++ b/src/graph/walker.rs
@@ -23,8 +23,12 @@ impl GraphWalker {
         }
     }
 
-    pub(crate) fn walk_graph<F>(&mut self, graph: &Graph, origin_node_idx: NodeIndex, predicate: F)
-    where
+    pub(crate) fn walk_graph<F>(
+        &mut self,
+        graph: &Graph<Node, Edge>,
+        origin_node_idx: NodeIndex,
+        predicate: F,
+    ) where
         F: Fn(&Edge, &Node, usize) -> bool,
     {
         self.visit_node_recursively(graph, origin_node_idx, 0, &predicate);
@@ -32,7 +36,7 @@ impl GraphWalker {
 
     pub(crate) fn visit_node_recursively<F>(
         &mut self,
-        graph: &Graph,
+        graph: &Graph<Node, Edge>,
         node_idx: NodeIndex,
         depth: usize,
         predicate: &F,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2,24 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use crate::item::Item;
-
 mod builder;
 
 pub(crate) use self::builder::TreeBuilder;
 
 #[derive(Clone, PartialEq, Debug)]
-pub struct Tree {
-    pub item: Item,
-    pub subtrees: Vec<Tree>,
+pub struct Tree<N> {
+    pub node: N,
+    pub subtrees: Vec<Tree<N>>,
 }
 
-impl Tree {
-    pub fn new(item: Item, subtrees: Vec<Tree>) -> Self {
-        Self { item, subtrees }
+impl<N> Tree<N> {
+    pub fn new(node: N, subtrees: Vec<Tree<N>>) -> Self {
+        Self { node, subtrees }
     }
 
-    pub fn push_subtree(&mut self, subtree: Tree) {
+    pub fn push_subtree(&mut self, subtree: Tree<N>) {
         self.subtrees.push(subtree);
     }
 }

--- a/src/tree/builder.rs
+++ b/src/tree/builder.rs
@@ -10,6 +10,8 @@ use scopeguard::defer;
 
 use crate::{item::Item, tree::Tree};
 
+type Node = Item;
+
 #[derive(Debug)]
 pub struct TreeBuilder<'a> {
     db: &'a RootDatabase,
@@ -21,7 +23,7 @@ impl<'a> TreeBuilder<'a> {
         Self { db, krate }
     }
 
-    pub fn build(mut self) -> anyhow::Result<Tree> {
+    pub fn build(mut self) -> anyhow::Result<Tree<Node>> {
         trace!("Scanning project...");
 
         defer! {
@@ -35,7 +37,7 @@ impl<'a> TreeBuilder<'a> {
         Ok(tree)
     }
 
-    fn process_crate(&mut self, crate_hir: Crate) -> Option<Tree> {
+    fn process_crate(&mut self, crate_hir: Crate) -> Option<Tree<Node>> {
         trace!("Processing crate {crate_hir:?}...");
 
         defer! {
@@ -47,7 +49,7 @@ impl<'a> TreeBuilder<'a> {
         self.process_module(module)
     }
 
-    fn process_impl(&mut self, impl_hir: hir::Impl) -> Vec<Tree> {
+    fn process_impl(&mut self, impl_hir: hir::Impl) -> Vec<Tree<Node>> {
         impl_hir
             .items(self.db)
             .into_iter()
@@ -61,7 +63,7 @@ impl<'a> TreeBuilder<'a> {
             .collect()
     }
 
-    fn process_moduledef(&mut self, module_def_hir: hir::ModuleDef) -> Option<Tree> {
+    fn process_moduledef(&mut self, module_def_hir: hir::ModuleDef) -> Option<Tree<Node>> {
         trace!("Processing moduledef {module_def_hir:?}...");
 
         defer! {
@@ -87,7 +89,7 @@ impl<'a> TreeBuilder<'a> {
         }
     }
 
-    fn process_module(&mut self, module_hir: hir::Module) -> Option<Tree> {
+    fn process_module(&mut self, module_hir: hir::Module) -> Option<Tree<Node>> {
         trace!("Processing module {module_hir:?}...");
 
         defer! {
@@ -109,7 +111,7 @@ impl<'a> TreeBuilder<'a> {
         Some(node)
     }
 
-    fn process_function(&mut self, function_hir: hir::Function) -> Option<Tree> {
+    fn process_function(&mut self, function_hir: hir::Function) -> Option<Tree<Node>> {
         trace!("Processing function {function_hir:?}...");
 
         defer! {
@@ -119,7 +121,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::Function(function_hir))
     }
 
-    fn process_adt(&mut self, adt_hir: hir::Adt) -> Option<Tree> {
+    fn process_adt(&mut self, adt_hir: hir::Adt) -> Option<Tree<Node>> {
         trace!("Processing adt {adt_hir:?}...");
 
         defer! {
@@ -143,7 +145,7 @@ impl<'a> TreeBuilder<'a> {
         node
     }
 
-    fn process_struct(&mut self, struct_hir: hir::Struct) -> Option<Tree> {
+    fn process_struct(&mut self, struct_hir: hir::Struct) -> Option<Tree<Node>> {
         trace!("Processing struct {struct_hir:?}...");
 
         defer! {
@@ -153,7 +155,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::Adt(hir::Adt::Struct(struct_hir)))
     }
 
-    fn process_enum(&mut self, enum_hir: hir::Enum) -> Option<Tree> {
+    fn process_enum(&mut self, enum_hir: hir::Enum) -> Option<Tree<Node>> {
         trace!("Processing enum {enum_hir:?}...");
 
         defer! {
@@ -163,7 +165,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::Adt(hir::Adt::Enum(enum_hir)))
     }
 
-    fn process_union(&mut self, union_hir: hir::Union) -> Option<Tree> {
+    fn process_union(&mut self, union_hir: hir::Union) -> Option<Tree<Node>> {
         trace!("Processing union {union_hir:?}...");
 
         defer! {
@@ -173,7 +175,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::Adt(hir::Adt::Union(union_hir)))
     }
 
-    fn process_variant(&mut self, variant_hir: hir::Variant) -> Option<Tree> {
+    fn process_variant(&mut self, variant_hir: hir::Variant) -> Option<Tree<Node>> {
         trace!("Processing variant {variant_hir:?}...");
 
         defer! {
@@ -183,7 +185,7 @@ impl<'a> TreeBuilder<'a> {
         None
     }
 
-    fn process_const(&mut self, const_hir: hir::Const) -> Option<Tree> {
+    fn process_const(&mut self, const_hir: hir::Const) -> Option<Tree<Node>> {
         trace!("Processing const {const_hir:?}...");
 
         defer! {
@@ -193,7 +195,7 @@ impl<'a> TreeBuilder<'a> {
         None
     }
 
-    fn process_static(&mut self, static_hir: hir::Static) -> Option<Tree> {
+    fn process_static(&mut self, static_hir: hir::Static) -> Option<Tree<Node>> {
         trace!("Processing static {static_hir:?}...");
 
         defer! {
@@ -203,7 +205,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::Static(static_hir))
     }
 
-    fn process_trait(&mut self, trait_hir: hir::Trait) -> Option<Tree> {
+    fn process_trait(&mut self, trait_hir: hir::Trait) -> Option<Tree<Node>> {
         trace!("Processing trait {trait_hir:?}...");
 
         defer! {
@@ -213,7 +215,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::Trait(trait_hir))
     }
 
-    fn process_trait_alias(&mut self, trait_alias_hir: hir::TraitAlias) -> Option<Tree> {
+    fn process_trait_alias(&mut self, trait_alias_hir: hir::TraitAlias) -> Option<Tree<Node>> {
         trace!("Processing trait alias {trait_alias_hir:?}...");
 
         defer! {
@@ -223,7 +225,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::TraitAlias(trait_alias_hir))
     }
 
-    fn process_type_alias(&mut self, type_alias_hir: hir::TypeAlias) -> Option<Tree> {
+    fn process_type_alias(&mut self, type_alias_hir: hir::TypeAlias) -> Option<Tree<Node>> {
         trace!("Processing type alias {type_alias_hir:?}...");
 
         defer! {
@@ -233,7 +235,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::TypeAlias(type_alias_hir))
     }
 
-    fn process_builtin_type(&mut self, builtin_type_hir: hir::BuiltinType) -> Option<Tree> {
+    fn process_builtin_type(&mut self, builtin_type_hir: hir::BuiltinType) -> Option<Tree<Node>> {
         trace!("Processing builtin type {builtin_type_hir:?}...");
 
         defer! {
@@ -243,7 +245,7 @@ impl<'a> TreeBuilder<'a> {
         self.simple_node(hir::ModuleDef::BuiltinType(builtin_type_hir))
     }
 
-    fn process_macro(&mut self, macro_hir: hir::Macro) -> Option<Tree> {
+    fn process_macro(&mut self, macro_hir: hir::Macro) -> Option<Tree<Node>> {
         trace!("Processing macro {macro_hir:?}...");
 
         defer! {
@@ -253,7 +255,7 @@ impl<'a> TreeBuilder<'a> {
         None
     }
 
-    fn simple_node(&mut self, module_def_hir: hir::ModuleDef) -> Option<Tree> {
+    fn simple_node(&mut self, module_def_hir: hir::ModuleDef) -> Option<Tree<Node>> {
         let item = Item::new(module_def_hir);
         Some(Tree::new(item, vec![]))
     }


### PR DESCRIPTION
This is to allow for writing more granular unit tests for individual graph/tree processing phases using dummy nodes and edges.