### PR TITLE
chore: fix the `clippy` errors for rust-1.78.0

### DIFF
--- a/src/command/dependencies/options.rs
+++ b/src/command/dependencies/options.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use clap::Parser;
 
@@ -36,9 +36,9 @@ impl FromStr for LayoutAlgorithm {
     }
 }
 
-impl ToString for LayoutAlgorithm {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for LayoutAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             Self::None => "none",
             Self::Dot => "dot",
             Self::Neato => "neato",
@@ -46,8 +46,7 @@ impl ToString for LayoutAlgorithm {
             Self::Circo => "circo",
             Self::Fdp => "fdp",
             Self::Sfdp => "sfdp",
-        }
-        .to_owned()
+        })
     }
 }
 

--- a/src/command/structure/options.rs
+++ b/src/command/structure/options.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use clap::Parser;
 
@@ -28,14 +28,13 @@ impl FromStr for SortBy {
     }
 }
 
-impl ToString for SortBy {
-    fn to_string(&self) -> String {
-        match self {
+impl Display for SortBy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             Self::Name => "name",
             Self::Visibility => "visibility",
             Self::Kind => "kind",
-        }
-        .to_owned()
+        })
     }
 }
 

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -19,6 +19,7 @@ use crate::{
     item::Item,
 };
 
+#[allow(unused)]
 #[derive(Debug, Hash, Eq, PartialEq)]
 struct Dependency {
     source_idx: NodeIndex,


### PR DESCRIPTION
chore: fix the `clippy` errors