### PR TITLE
fix(analyzer): fix the issue that cannot get the glob pattern submodules' metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Fixed
 
-- n/a
+- Don't call `.canonicalize()` on the project path on Windows to avoid cargo incompatibility with verbatim paths.
 
 ### Performance
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -38,7 +38,20 @@ pub fn load_workspace(
     project_options: &ProjectOptions,
     load_options: &LoadOptions,
 ) -> anyhow::Result<(Crate, AnalysisHost, Vfs)> {
-    let project_path = project_options.manifest_path.as_path().canonicalize()?;
+    let project_path = {
+        let project_path = project_options.manifest_path.as_path();
+
+        // See: https://github.com/rust-lang/cargo/pull/13909
+        // The `canonicalize` func on windows will return `r"\\?\"` verbatim prefix.
+        // "The Cargo makes a core assumption that verbatim paths aren't used."
+        // So we cannot use this func on windows.
+        if cfg!(windows) {
+            project_path.to_path_buf()
+        } else {
+            project_path.canonicalize()?
+        }
+    };
+
     let cargo_config = cargo_config(project_options, load_options);
     let load_config = load_config();
 


### PR DESCRIPTION
OS: windows 11
rustc: rustc 1.78.0 (9b00956e5 2024-04-29)
cargo: cargo 1.78.0 (54d8815d0 2024-03-26)

`cargo-modules` version:
![image](https://github.com/regexident/cargo-modules/assets/24818903/56c58111-0afd-40c0-a67f-41dbc29f5cac)


Hi Vincent~

I pulled down the latest source code from `rust-lang/cargo` repo, and then exec `cargo modules structure` under its root directory, then I got the error:
![image](https://github.com/regexident/cargo-modules/assets/24818903/3b98a5be-00e6-4b7d-9ab5-0c1be644a64a)

After debugged the `cargo-modules` sourcecode, I finally found that it due to failed to get the cargo metadata when the arg `--manifest-path`'s value is with `Verbatim Disk prefix`.
E.g.
![image](https://github.com/regexident/cargo-modules/assets/24818903/f0ee1dd2-ba03-41d2-af36-6f0d692ede3b)

After rose up a [PR](https://github.com/rust-lang/cargo/pull/13909) for the `rust-lang/cargo` repo, the owner notice me maybe it is the wrong invoking from the `cargo-modules`.

Due to the `glob` crate hadn't updated the semver yet for correctly get the sub paths from `glob(r"\\?\E:\Codes\Source\cargo\crates\*\Cargo.toml")`, maybe we'd better to not to use the `canonicalize` func to change the manifest path value on windows only~ 😉
