### PR TITLE
Make sure that the tests are running without `backtrace`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ issue trackers, chatrooms, and mailing lists.
 
 1. Fork the repo (preferably on a feature-branch).
 
+    If you are using **Windows system**, please clone the repo with `git clone -c core.symlinks=true <repo url>`. 'Cause here are some symlink-like files under the `tests/projects` directory, these work well on Linux system, but not on Windows system. So you need to transform them as real symlinks through setting `core.symlinks=true` when cloning.
+
 2. Make your changes.
 
 3. Make sure your changes make the tests pass:

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -10,7 +10,7 @@ use shellwords::split;
 // See: https://github.com/rust-lang/rust-analyzer/blob/21ec8f523812b88418b2bfc64240c62b3dd967bd/crates/rust-analyzer/src/bin/main.rs#L105
 // See: https://github.com/rust-lang/rust-analyzer/blob/21ec8f523812b88418b2bfc64240c62b3dd967bd/editors/code/src/run.ts#L73
 fn correct_cmd_env(command: &mut Command) {
-    // The baseline snapshots (fixtures) make core without `backtrace`.
+    // The baseline snapshots (fixtures) make core assumption that tests are running without `backtrace`.
     // So we need to make sure that currently the command is without `backtrace` as well.
     if std::env::var("RUST_BACKTRACE").is_ok_and(|v| !v.is_empty()) {
         command.env("RUST_BACKTRACE", "0");


### PR DESCRIPTION
Make sure that the tests are running without `backtrace`.

If trigger the `cargo test` through the vscode `rust-analyzer` plugin, the env `RUST_BACKTRACE` will automatically be set as `short` before starting tests.

And then the snapshot assertion will be failed 'cause the generated snapshot will contain the unnecessary `backstrace` contents.

![image](https://github.com/regexident/cargo-modules/assets/24818903/eb2ce0c6-3630-47b5-a8ae-1b5f5ecbff3a)

![image](https://github.com/regexident/cargo-modules/assets/24818903/a851e09c-32dd-415b-8279-1f1d81b9d059)

And add the warm notice for Windows users who want to do some code contributing to this project.
