### PR TITLE
Simplify the `canonicalized` file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "bitflags 2.5.0",
  "bitvec",
  "clap",
+ "dunce",
  "env_logger",
  "getopts",
  "indoc",
@@ -411,6 +412,12 @@ name = "drop_bomb"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = "0.11.3"
 indoc = "2.0.5"
 clap = { version = "4.5.4", features = ["derive"] }
 scopeguard = "1.2.0"
+dunce = "1.0.4"
 
 ra_ap_base_db = "=0.0.216"
 ra_ap_cfg = "=0.0.216"

--- a/src/command/orphans/printer.rs
+++ b/src/command/orphans/printer.rs
@@ -41,6 +41,11 @@ impl<'a> Printer<'a> {
         })
         .expect("canonical path");
 
+        // The `canonicalize()` invoking can make sure the file path is meaningful.
+        // But on Windows, this invoking will make the path be with verbatim path prefix.
+        // So, we needs to make the path `simplified`, otherwise the `strip_prefix()` invoking will be failed.
+        let prefix_path = dunce::simplified(&prefix_path).to_path_buf();
+
         writeln!(f)?;
         writeln!(f, "{count} orphans found:", count = orphans.len())?;
         writeln!(f)?;


### PR DESCRIPTION
Simplify the `canonicalized` file path.

![image](https://github.com/regexident/cargo-modules/assets/24818903/39369e99-faf8-4d39-ba06-b5e517469265)

When contributing the repo [rolldown](https://github.com/rolldown/rolldown), I found that it used a popular crate named [dunce](https://crates.io/crates/dunce) to normalize the Windows file paths at [here](https://github.com/rolldown/rolldown/blob/6a520620b5635f15e354001ff07a645dd3087437/crates/rolldown/tests/fixtures.rs#L31).

Expected behavior:

![image](https://github.com/regexident/cargo-modules/assets/24818903/b5b6f9a6-273c-4a7e-82c8-bfa64ebd2c75)

