### PR TITLE
Some enhancements, mainly for fixing the failures when testing on Windows system.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Fixed
 
-- n/a
+- Fixed differences in test snapshots between macOS/Linux and Windows.
 
 ### Performance
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "rust-analyzer-salsa-macros",
  "scopeguard",
  "shellwords",
+ "sugar_path",
  "thread_local",
  "wyz 0.6.1",
  "yansi",
@@ -1873,6 +1874,12 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "sugar_path"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8230d5b8a65a6d4d4a7e5ee8dbdd9312ba447a8b8329689a390a0945d69b57ce"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ indoc = "2.0.5"
 clap = { version = "4.5.4", features = ["derive"] }
 scopeguard = "1.2.0"
 dunce = "1.0.4"
+sugar_path = "1.2.0"
 
 ra_ap_base_db = "=0.0.216"
 ra_ap_cfg = "=0.0.216"

--- a/src/command.rs
+++ b/src/command.rs
@@ -21,6 +21,7 @@ pub mod structure;
 #[derive(Parser, Clone, PartialEq, Eq, Debug)]
 #[command(
     name = "cargo-modules",
+    bin_name = "cargo-modules",
     about = "Visualize/analyze a crate's internal structure."
 )]
 pub enum Command {

--- a/src/command/orphans/printer.rs
+++ b/src/command/orphans/printer.rs
@@ -5,6 +5,7 @@
 //! Printer for displaying module structure as a tree.
 
 use ra_ap_ide::RootDatabase;
+use sugar_path::SugarPath as _;
 use yansi::Paint as _;
 
 use super::{options::Options, orphan::Orphan, theme::styles};
@@ -55,14 +56,14 @@ impl<'a> Printer<'a> {
                 .file_path
                 .strip_prefix(&prefix_path)
                 .expect("relative path")
-                .to_string_lossy();
+                .to_slash_lossy(); // Change the slashes from `\` to `/` on Windows.
 
             let parent_module_path = &orphan.parent_module_path;
             let parent_file_path = orphan
                 .parent_file_path
                 .strip_prefix(&prefix_path)
                 .expect("relative path")
-                .to_string_lossy();
+                .to_slash_lossy(); // Change the slashes from `\` to `/` on Windows.
 
             let issue = if self.options.deny {
                 "error".paint(styles.error)


### PR DESCRIPTION
1. Add a new crate named `sugar_path`. When the command found the `orphans`, the printed file path should be with the `/` forward-slash, otherwise it will be different with the existed fixture/baseline snapshot. E.g., on Windows system, the file path is with `\` backward-slash.

![image](https://github.com/regexident/cargo-modules/assets/24818903/ffd6e96d-387a-4d3f-a5be-e1c02433e7da)


2. Need to point out the `bin_name` property on the `clap command` attrbute-macro, otherwise it will print `cargo-modules.exe` on Windows system.

![image](https://github.com/regexident/cargo-modules/assets/24818903/379436d6-e0f8-49ab-97ef-7de415eb2ef1)
  It only depends on how to invoking the `cargo-modules` executable binary file from the shell. And due to that the `Command::cargo_bin("cargo-modules").unwrap()` invoking which is under the `tests/util.rs 58:23` is executing the binary file with the `std::env::consts::EXE_SUFFIX` which equals `.exe` on Windows system.
  ![image](https://github.com/regexident/cargo-modules/assets/24818903/bf257394-9ad8-4f25-9b73-dc36bd85f05a)

  After set the `bin_name` as `cargo-modules`:
  ![image](https://github.com/regexident/cargo-modules/assets/24818903/f064469b-4f50-4b11-8bf2-073e33977602)


---------

Nice, eventually, all the test cases passed on the Windows system. Hurray for it!

![image](https://github.com/regexident/cargo-modules/assets/24818903/d779621a-b68c-45a5-b0bb-dcbc019d844f)