### PR TITLE
Fix a bug that would filter out all items with a `#[cfg(…)]`, given `--cfg_test "false"`, not just those with `#[cfg(test)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Fixed
 
-- n/a
+- Fixed a bug that would filter out all items with a `#[cfg(…)]`, given `--cfg_test "false"`, not just those with `#[cfg(test)]`.
 
 ### Performance
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -683,7 +683,7 @@ pub(crate) fn has_test_cfg(hir: hir::ModuleDef, db: &ide::RootDatabase) -> bool 
                     CfgAtom::KeyValue { .. } => false,
                 }
             })
-            .is_some()
+            .unwrap_or_default()
     })
 }
 

--- a/tests/dependencies.rs
+++ b/tests/dependencies.rs
@@ -568,4 +568,14 @@ mod github {
             project: github_issue_172
         );
     }
+
+    mod issue_362 {
+        test_cmd!(
+            args: "dependencies \
+                    --features 'opt-in'",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: github_issue_362
+        );
+    }
 }

--- a/tests/projects/github_issue_362/Cargo.toml
+++ b/tests/projects/github_issue_362/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "github_issue_362"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+default = ["on-by-default"]
+opt-in = []
+off-by-default = []
+on-by-default = []

--- a/tests/projects/github_issue_362/src/lib.rs
+++ b/tests/projects/github_issue_362/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "on-by-default")]
+mod on_by_default {}
+
+#[cfg(feature = "opt-in")]
+mod opt_in {}
+
+#[cfg(feature = "off-by-default")]
+mod off_by_default {}

--- a/tests/snapshots/dependencies__github__issue_362__github_issue_362.snap
+++ b/tests/snapshots/dependencies__github__issue_362__github_issue_362.snap
@@ -42,6 +42,10 @@ digraph {
     ];
 
     "github_issue_362" [label="crate|github_issue_362", fillcolor="#5397c8"]; // "crate" node
+    "github_issue_362::on_by_default" [label="pub(crate) mod|github_issue_362::on_by_default", fillcolor="#f8c04c"]; // "mod" node
+    "github_issue_362::opt_in" [label="pub(crate) mod|github_issue_362::opt_in", fillcolor="#f8c04c"]; // "mod" node
 
+    "github_issue_362" -> "github_issue_362::on_by_default" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_362" -> "github_issue_362::opt_in" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }

--- a/tests/snapshots/dependencies__github__issue_362__github_issue_362.snap
+++ b/tests/snapshots/dependencies__github__issue_362__github_issue_362.snap
@@ -1,0 +1,47 @@
+---
+source: tests/dependencies.rs
+expression: output
+---
+COMMAND:
+dependencies
+--features
+opt-in
+
+STDERR:
+
+STDOUT:
+digraph {
+
+    graph [
+        label="github_issue_362",
+        labelloc=t,
+
+        pad=0.4,
+
+        // Consider rendering the graph using a different layout algorithm, such as:
+        // [dot, neato, twopi, circo, fdp, sfdp]
+        layout=neato,
+        overlap=false,
+        splines="line",
+        rankdir=LR,
+
+        fontname="Helvetica", 
+        fontsize="36",
+    ];
+
+    node [
+        fontname="monospace",
+        fontsize="10",
+        shape="record",
+        style="filled",
+    ];
+
+    edge [
+        fontname="monospace",
+        fontsize="10",
+    ];
+
+    "github_issue_362" [label="crate|github_issue_362", fillcolor="#5397c8"]; // "crate" node
+
+
+}

--- a/tests/snapshots/dependencies__github__issue_80__without_tests__github_issue_80.snap
+++ b/tests/snapshots/dependencies__github__issue_80__without_tests__github_issue_80.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/dependencies.rs
 expression: output
-snapshot_kind: text
 ---
 COMMAND:
 dependencies
@@ -44,23 +43,29 @@ digraph {
     ];
 
     "github_issue_80" [label="crate|github_issue_80", fillcolor="#5397c8"]; // "crate" node
+    "github_issue_80::OnlyExistsWithoutTest" [label="pub struct|OnlyExistsWithoutTest", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::Placebo" [label="pub struct|Placebo", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::imported" [label="pub mod|imported", fillcolor="#81c169"]; // "mod" node
     "github_issue_80::imported::OnlyUsedWithTest" [label="pub struct|imported::OnlyUsedWithTest", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::imported::OnlyUsedWithoutTest" [label="pub struct|imported::OnlyUsedWithoutTest", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::imported::Placebo" [label="pub struct|imported::Placebo", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::importing" [label="pub mod|importing", fillcolor="#81c169"]; // "mod" node
+    "github_issue_80::only_exists_without_test" [label="pub mod|only_exists_without_test", fillcolor="#81c169"]; // "mod" node
+    "github_issue_80::only_exists_without_test::OnlyExistsWithoutTest" [label="pub struct|only_exists_without_test::OnlyExistsWithoutTest", fillcolor="#81c169"]; // "struct" node
     "github_issue_80::only_exists_without_test::Placebo" [label="pub struct|only_exists_without_test::Placebo", fillcolor="#81c169"]; // "struct" node
 
+    "github_issue_80" -> "github_issue_80::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80" -> "github_issue_80::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80" -> "github_issue_80::imported" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
     "github_issue_80" -> "github_issue_80::importing" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
-    "github_issue_80" -> "github_issue_80::only_exists_without_test::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80" -> "github_issue_80::only_exists_without_test" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80::imported" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80::imported" -> "github_issue_80::imported::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
     "github_issue_80::importing" -> "github_issue_80::imported::OnlyUsedWithoutTest" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
     "github_issue_80::importing" -> "github_issue_80::imported::Placebo" [label="uses", color="#7f7f7f", style="dashed"] [constraint=false]; // "uses" edge
+    "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::OnlyExistsWithoutTest" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
+    "github_issue_80::only_exists_without_test" -> "github_issue_80::only_exists_without_test::Placebo" [label="owns", color="#000000", style="solid"] [constraint=true]; // "owns" edge
 
 }

--- a/tests/snapshots/structure__github__issue_362__github_issue_362.snap
+++ b/tests/snapshots/structure__github__issue_362__github_issue_362.snap
@@ -1,0 +1,14 @@
+---
+source: tests/structure.rs
+expression: output
+---
+COMMAND:
+structure
+--features
+opt-in
+
+STDERR:
+
+STDOUT:
+
+crate github_issue_362

--- a/tests/snapshots/structure__github__issue_362__github_issue_362.snap
+++ b/tests/snapshots/structure__github__issue_362__github_issue_362.snap
@@ -12,3 +12,5 @@ STDERR:
 STDOUT:
 
 crate github_issue_362
+├── mod on_by_default: pub(crate) #[cfg(feature = "on-by-default")]
+└── mod opt_in: pub(crate) #[cfg(feature = "opt-in")]

--- a/tests/snapshots/structure__github__issue_80__without_tests__github_issue_80.snap
+++ b/tests/snapshots/structure__github__issue_80__without_tests__github_issue_80.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/structure.rs
 expression: output
-snapshot_kind: text
 ---
 COMMAND:
 structure
@@ -13,9 +12,13 @@ STDERR:
 STDOUT:
 
 crate github_issue_80
+├── struct OnlyExistsWithoutTest: pub #[cfg(not(test))]
 ├── struct Placebo: pub
 ├── mod imported: pub
 │   ├── struct OnlyUsedWithTest: pub
 │   ├── struct OnlyUsedWithoutTest: pub
 │   └── struct Placebo: pub
-└── mod importing: pub
+├── mod importing: pub
+└── mod only_exists_without_test: pub #[cfg(not(test))]
+    ├── struct OnlyExistsWithoutTest: pub #[cfg(not(test))]
+    └── struct Placebo: pub

--- a/tests/structure.rs
+++ b/tests/structure.rs
@@ -525,4 +525,14 @@ mod github {
             project: github_issue_222
         );
     }
+
+    mod issue_362 {
+        test_cmd!(
+            args: "structure \
+                    --features 'opt-in'",
+            success: true,
+            color_mode: ColorMode::Plain,
+            project: github_issue_362
+        );
+    }
 }


### PR DESCRIPTION
Fixes #362.